### PR TITLE
add functional modifiers

### DIFF
--- a/addon/-private/functional-modifier-manager.js
+++ b/addon/-private/functional-modifier-manager.js
@@ -1,0 +1,49 @@
+import { capabilities } from '@ember/modifier';
+
+const MODIFIER_ELEMENTS = new WeakMap();
+const MODIFIER_TEARDOWNS = new WeakMap();
+
+function teardown(modifier) {
+  const teardown = MODIFIER_TEARDOWNS.get(modifier);
+
+  if (teardown && typeof teardown === 'function') {
+    teardown();
+  }
+}
+
+function setup(modifier, element, args) {
+  const { positional, named } = args;
+  const teardown = modifier(element, positional, named);
+
+  MODIFIER_TEARDOWNS.set(modifier, teardown);
+}
+
+export default class FunctionalModifierManager {
+  capabilities = capabilities('3.13');
+
+  createModifier(factory) {
+    const { class: fn } = factory;
+
+    // This looks superfluous, but this is creating a new instance
+    // of a function -- this is important so that each instance of the
+    // created modifier can have its own state which is stored in
+    // the MODIFIER_ELEMENTS and MODIFIER_TEARDOWNS WeakMaps
+    return (...args) => fn(...args);
+  }
+
+  installModifier(modifier, element, args) {
+    MODIFIER_ELEMENTS.set(modifier, element);
+    setup(modifier, element, args);
+  }
+
+  updateModifier(modifier, args) {
+    const element = MODIFIER_ELEMENTS.get(modifier);
+
+    teardown(modifier);
+    setup(modifier, element, args);
+  }
+
+  destroyModifier(modifier) {
+    teardown(modifier);
+  }
+}

--- a/addon/-private/functional-modifier.js
+++ b/addon/-private/functional-modifier.js
@@ -1,0 +1,18 @@
+import { setModifierManager } from '@ember/modifier';
+import FunctionalModifierManager from './functional-modifier-manager';
+
+const MANAGERS = new WeakMap();
+
+function managerFor(owner) {
+  let manager = MANAGERS.get(owner);
+
+  if (manager === undefined) {
+    manager = new FunctionalModifierManager(owner);
+  }
+
+  return manager;
+}
+
+export default function modifier(fn) {
+  return setModifierManager(managerFor, fn);
+}

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,2 +1,2 @@
 export { default } from 'ember-class-based-modifier';
-export { default as modifier } from 'ember-functional-modifiers';
+export { default as modifier } from './-private/functional-modifier';

--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
   "dependencies": {
     "ember-class-based-modifier": "^0.10.0",
     "ember-cli-babel": "^7.11.1",
-    "ember-cli-htmlbars": "^4.0.0",
-    "ember-functional-modifiers": "^0.5.0"
+    "ember-cli-htmlbars": "^4.0.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^1.0.0",

--- a/tests/integration/modifiers/functional-modifier-test.js
+++ b/tests/integration/modifiers/functional-modifier-test.js
@@ -1,0 +1,141 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, settled } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { modifier } from 'ember-modifier';
+
+module('Integration | Modifiers | functional modifier', function(hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.registerModifier = (name, modifier) => {
+      this.owner.register(`modifier:${name}`, modifier);
+    };
+  });
+
+  module('args', () => {
+    test('it passes element as first argument', async function(assert) {
+      this.registerModifier(
+        'songbird',
+        modifier(element => assert.equal(element.tagName, 'H1'))
+      );
+
+      await render(hbs`<h1 {{songbird}}>Hello</h1>`);
+    });
+
+    test('positional arguments are passed', async function(assert) {
+      this.registerModifier(
+        'songbird',
+        modifier((_, [a, b]) => {
+          assert.equal(a, '1');
+          assert.equal(b, '2');
+        })
+      );
+
+      await render(hbs`<h1 {{songbird "1" "2"}}>Hey</h1>`);
+    });
+
+    test('named arguments are passed', async function(assert) {
+      this.registerModifier(
+        'songbird',
+        modifier((_, __, { a, b }) => {
+          assert.equal(a, '1');
+          assert.equal(b, '2');
+        })
+      );
+
+      await render(hbs`<h1 {{songbird a="1" b="2"}}>Hey</h1>`);
+    });
+  });
+
+  module('setup/teardown', () => {
+    test('teardown method called when removed', async function(assert) {
+      let callCount = 0;
+      this.shouldRender = true;
+
+      this.registerModifier(
+        'songbird',
+        modifier(() => () => callCount++)
+      );
+
+      await render(hbs`
+        {{#if this.shouldRender}}
+          <h1 {{songbird value}}>Hello</h1>
+        {{/if}}
+      `);
+
+      assert.equal(callCount, 0);
+
+      this.set('shouldRender', false);
+
+      await settled();
+
+      assert.equal(callCount, 1);
+    });
+
+    test('setup is invoked for each change', async function(assert) {
+      let callCount = 0;
+      this.value = 0;
+
+      this.registerModifier(
+        'songbird',
+        modifier(() => callCount++)
+      );
+
+      await render(hbs`<h1 {{songbird value}}>Hello</h1>`);
+
+      assert.equal(callCount, 1);
+
+      this.set('value', 1);
+
+      await settled();
+
+      assert.equal(callCount, 2);
+    });
+
+    test('teardown is invoked for each change', async function(assert) {
+      let callCount = 0;
+      this.value = 0;
+
+      this.registerModifier(
+        'songbird',
+        modifier(() => () => callCount++)
+      );
+
+      await render(hbs`<h1 {{songbird value}}>Hello</h1>`);
+
+      assert.equal(callCount, 0);
+
+      this.set('value', 1);
+
+      await settled();
+
+      assert.equal(callCount, 1);
+    });
+
+    test('teardown is invoked for each modifier instance', async function(assert) {
+      let teardownCalls = [];
+      this.isRendered = true;
+
+      this.registerModifier(
+        'songbird',
+        modifier((_, [val]) => () => teardownCalls.push(val))
+      );
+
+      await render(hbs`
+        {{#if isRendered}}
+          <h1 {{songbird "A"}}>A</h1>
+          <h1 {{songbird "B"}}>B</h1>
+        {{/if}}
+      `);
+
+      this.set('isRendered', false);
+
+      await settled();
+
+      assert.equal(teardownCalls.length, 2);
+      assert.ok(teardownCalls.includes('A'));
+      assert.ok(teardownCalls.includes('B'));
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3107,7 +3107,7 @@ ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.1.2, ember-cli-babel@^7.10.0, ember-cli-babel@^7.11.0, ember-cli-babel@^7.11.1, ember-cli-babel@^7.7.0, ember-cli-babel@^7.7.3, ember-cli-babel@^7.8.0:
+ember-cli-babel@^7.1.2, ember-cli-babel@^7.10.0, ember-cli-babel@^7.11.1, ember-cli-babel@^7.7.0, ember-cli-babel@^7.7.3, ember-cli-babel@^7.8.0:
   version "7.12.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.12.0.tgz#064997d199384be8c88d251f30ef67953d3bddc5"
   integrity sha512-+EGQsbPvh19nNXHCm6rVBx2CdlxQlzxMyhey5hsGViDPriDI4PFYXYaFWdGizDrmZoDcG/Ywpeph3hl0NxGQTg==
@@ -3452,14 +3452,6 @@ ember-export-application-global@^2.0.0:
   dependencies:
     ember-cli-babel "^6.0.0-beta.7"
 
-ember-functional-modifiers@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/ember-functional-modifiers/-/ember-functional-modifiers-0.5.0.tgz#85c0d37ccdb45f4ab55037d6c66189faabe79e32"
-  integrity sha512-gOOqVXsgIu+Ch6XhAFVAKfaY3krQMRk2R0rE7HGtPQVEIHXUZKqJ/+cZFXG+XiM+gTvp2jOZ4jjYJ4Daa/jPqg==
-  dependencies:
-    ember-cli-babel "^7.11.0"
-    ember-modifier-manager-polyfill "^1.1.0"
-
 ember-load-initializers@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ember-load-initializers/-/ember-load-initializers-2.1.0.tgz#b402815ab9c823ff48a1369b52633721987e72d4"
@@ -3478,7 +3470,7 @@ ember-maybe-import-regenerator@^0.1.6:
     ember-cli-babel "^6.0.0-beta.4"
     regenerator-runtime "^0.9.5"
 
-ember-modifier-manager-polyfill@^1.1.0, ember-modifier-manager-polyfill@^1.2.0:
+ember-modifier-manager-polyfill@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.2.0.tgz#cf4444e11a42ac84f5c8badd85e635df57565dda"
   integrity sha512-bnaKF1LLKMkBNeDoetvIJ4vhwRPKIIumWr6dbVuW6W6p4QV8ZiO+GdF8J7mxDNlog9CeL9Z/7wam4YS86G8BYA==


### PR DESCRIPTION
This brings over the functionality from `ember-functional-modifiers` with a few changes:

1. Removes the `isRemoving` flag passed to the teardown method
2. Removes Service injection functionality 
3. A teeny bit of refactoring to the Weak Map state attached to the modifier functions