### PR TITLE
Add blueprint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,5 @@
 # unconventional js
-/blueprints/*/files/
+blueprints/*/*files/**/*.js
 /vendor/
 
 # compiled output

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,7 +27,7 @@ module.exports = {
         'ember-cli-build.js',
         'index.js',
         'testem.js',
-        'blueprints/*/index.js',
+        'blueprints/**/*.js',
         'config/**/*.js',
         'tests/dummy/config/**/*.js'
       ],

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ first place.
 To create a modifier (and a corresponding integration test), run:
 
 ```
-ember g functional-modifier scroll-top
+ember g modifier scroll-top
 ```
 
 #### Example without Cleanup
@@ -206,6 +206,14 @@ comes along with much more _control_.
 As with functional modifiers, the lifecycle hooks of class modifiers are
 _tracked_. When they run, they any values they access will be added to the
 modifier, and the modifier will update if any of those values change.
+
+#### Generating a Class Modifier
+
+To create a modifier (and a corresponding integration test), run:
+
+```
+ember g modifier scroll-top --class
+```
 
 #### Example without Cleanup
 

--- a/blueprints/.eslintrc.js
+++ b/blueprints/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  env: {
+    node: true
+  }
+}

--- a/blueprints/modifier-test/index.js
+++ b/blueprints/modifier-test/index.js
@@ -1,0 +1,80 @@
+'use strict';
+
+const stringUtils = require('ember-cli-string-utils');
+const isPackageMissing = require('ember-cli-is-package-missing');
+
+const useTestFrameworkDetector = require('../test-framework-detector');
+const isModuleUnificationProject = require('../module-unification').isModuleUnificationProject;
+
+const path = require('path');
+
+module.exports = useTestFrameworkDetector({
+  description: 'Generates a helper integration test or a unit test.',
+
+  fileMapTokens: function() {
+    if (isModuleUnificationProject(this.project)) {
+      return {
+        __root__(options) {
+          if (options.inRepoAddon) {
+            return path.join('packages', options.inRepoAddon, 'src');
+          }
+
+          if (options.inDummy) {
+            throw new Error("The --dummy flag isn't supported within a module unification app");
+          }
+
+          return 'src';
+        },
+        __testType__() {
+          return '';
+        },
+        __collection__() {
+          return 'ui/components';
+        },
+      };
+    } else {
+      return {
+        __root__() {
+          return 'tests';
+        },
+        __testType__(options) {
+          return options.locals.testType || 'integration';
+        },
+        __collection__() {
+          return 'modifiers';
+        },
+      };
+    }
+  },
+
+  locals: function(options) {
+    let friendlyTestName = ['Integration', 'Modifier', options.entity.name].join(' | ');
+    let dasherizedModulePrefix;
+
+    if (
+      isModuleUnificationProject(options.project) &&
+      (options.project.isEmberCLIAddon() || options.inRepoAddon)
+    ) {
+      dasherizedModulePrefix = options.inRepoAddon || options.project.name();
+    } else {
+      dasherizedModulePrefix = stringUtils.dasherize(options.project.config().modulePrefix);
+    }
+
+    return {
+      friendlyTestName: friendlyTestName,
+      dasherizedModulePrefix: dasherizedModulePrefix
+    };
+  },
+
+  afterInstall: function(options) {
+    if (
+      !options.dryRun &&
+      options.testType === 'integration' &&
+      isPackageMissing(this, 'ember-cli-htmlbars-inline-precompile')
+    ) {
+      return this.addPackagesToProject([
+        { name: 'ember-cli-htmlbars-inline-precompile', target: '^0.3.1' },
+      ]);
+    }
+  },
+});

--- a/blueprints/modifier-test/mocha-files/__root__/integration/__collection__/__name__-test.js
+++ b/blueprints/modifier-test/mocha-files/__root__/integration/__collection__/__name__-test.js
@@ -1,0 +1,16 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile'
+
+describe('<%= friendlyTestName %>', function() {
+  setupRenderingTest();
+
+  // Replace this with your real tests.
+  it('renders', async function() {
+    await render(hbs`<div {{<%= dasherizedModuleName %>}}></div>`);
+
+    expect(true).to.be.true;
+  });
+});

--- a/blueprints/modifier-test/qunit-files/__root__/integration/__collection__/__name__-test.js
+++ b/blueprints/modifier-test/qunit-files/__root__/integration/__collection__/__name__-test.js
@@ -1,0 +1,15 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('<%= friendlyTestName %>', function(hooks) {
+  setupRenderingTest(hooks);
+
+  // Replace this with your real tests.
+  test('it renders', async function(assert) {
+    await render(hbs`<div {{<%= dasherizedModuleName %>}}></div>`);
+
+    assert.ok(true);
+  });
+});

--- a/blueprints/modifier/files/__root__/__collection__/__name__.js
+++ b/blueprints/modifier/files/__root__/__collection__/__name__.js
@@ -1,0 +1,5 @@
+import { modifier } from 'ember-modifier';
+
+export default modifier(function <%= camelizedModuleName %>(element/*, params, hash*/) {
+
+});

--- a/blueprints/modifier/files/__root__/__collection__/__name__.js
+++ b/blueprints/modifier/files/__root__/__collection__/__name__.js
@@ -1,5 +1,9 @@
-import { modifier } from 'ember-modifier';
+<% if (modifierType === 'function') { %>import { modifier } from 'ember-modifier';
 
 export default modifier(function <%= camelizedModuleName %>(element/*, params, hash*/) {
 
-});
+});<% } else { %>import Modifier from 'ember-modifier';
+
+export default class <%= classifiedModuleName %>Modifier extends Modifier {
+
+}<% } %>

--- a/blueprints/modifier/index.js
+++ b/blueprints/modifier/index.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const isModuleUnificationProject = require('../module-unification').isModuleUnificationProject;
+const normalizeEntityName = require('ember-cli-normalize-entity-name');
+
+const path = require('path');
+
+module.exports = {
+  description: 'Generates a modifier function.',
+
+  filesPath() {
+    let rootPath = isModuleUnificationProject(this.project) ? 'mu-files' : 'files';
+    return path.join(this.path, rootPath);
+  },
+
+  fileMapTokens() {
+    if (isModuleUnificationProject(this.project)) {
+      return {
+        __root__(options) {
+          if (options.pod) {
+            throw new Error("Pods aren't supported within a module unification app");
+          }
+
+          if (options.inRepoAddon) {
+            return path.join('packages', options.inRepoAddon, 'src');
+          }
+
+          if (options.inDummy) {
+            return path.join('tests', 'dummy', 'src');
+          }
+
+          return 'src';
+        },
+        __collection__(options) {
+          if (options.pod) {
+            throw new Error("Pods aren't supported within a module unification app");
+          }
+
+          return path.join('ui', 'components');
+        },
+      };
+    } else {
+      return {
+        __collection__() {
+          return 'modifiers';
+        },
+      };
+    }
+  },
+
+  normalizeEntityName: function(entityName) {
+    return normalizeEntityName(
+      entityName.replace(/\.js$/, '') //Prevent generation of ".js.js" files
+    );
+  },
+};

--- a/blueprints/modifier/index.js
+++ b/blueprints/modifier/index.js
@@ -6,7 +6,22 @@ const normalizeEntityName = require('ember-cli-normalize-entity-name');
 const path = require('path');
 
 module.exports = {
-  description: 'Generates a modifier function.',
+  description: 'Generates a modifier.',
+
+  availableOptions: [
+    {
+      name: 'modifier-type',
+      type: ['function', 'class'],
+      default: 'function',
+      aliases: [
+        { f: 'function' },
+        { s: 'class' },
+        { function: 'function' },
+        { functional: 'function' },
+        { class: 'class' }
+      ]
+    }
+  ],
 
   filesPath() {
     let rootPath = isModuleUnificationProject(this.project) ? 'mu-files' : 'files';
@@ -48,9 +63,14 @@ module.exports = {
     }
   },
 
-  normalizeEntityName: function(entityName) {
+  normalizeEntityName(entityName) {
     return normalizeEntityName(
       entityName.replace(/\.js$/, '') //Prevent generation of ".js.js" files
     );
   },
+
+  locals(options) {
+    let modifierType = options.modifierType || 'function';
+    return { modifierType };
+  }
 };

--- a/blueprints/modifier/mu_files/__root__/__collection__/__name__.js
+++ b/blueprints/modifier/mu_files/__root__/__collection__/__name__.js
@@ -1,0 +1,5 @@
+import { modifier } from 'ember-modifier';
+
+export default modifier(function <%= camelizedModuleName %>(element/*, params, hash*/) {
+
+});

--- a/blueprints/module-unification.js
+++ b/blueprints/module-unification.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+  isModuleUnificationProject(project) {
+    return project && project.isModuleUnification && project.isModuleUnification();
+  },
+};

--- a/blueprints/test-framework-detector.js
+++ b/blueprints/test-framework-detector.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const path = require('path');
+
+module.exports = function(blueprint) {
+  blueprint.supportsAddon = function() {
+    return false;
+  };
+
+  blueprint.filesPath = function() {
+    let type;
+
+    let dependencies = this.project.dependencies();
+
+    if ('ember-qunit' in dependencies) {
+      type = 'qunit';
+    } else if ('ember-mocha' in dependencies) {
+      type = 'mocha';
+    } else {
+      this.ui.writeLine("Couldn't determine test style - using QUnit");
+      type = 'qunit';
+    }
+
+    return path.join(this.path, type + '-files');
+  };
+
+  return blueprint;
+};

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
   },
   "dependencies": {
     "ember-cli-babel": "^7.11.1",
+    "ember-cli-is-package-missing": "^1.0.0",
+    "ember-cli-normalize-entity-name": "^1.0.0",
+    "ember-cli-string-utils": "^1.1.0",
     "ember-modifier-manager-polyfill": "^1.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### Description 
This PR adds a blueprint for both Functional and Class-based modifiers. 

This largely follows the pattern of the blueprints for helpers (helper [here](https://github.com/emberjs/ember.js/tree/18067782490dc8cc812adf74de5ee9e8ad8e081e/blueprints/helper) and tests [here](https://github.com/emberjs/ember.js/tree/18067782490dc8cc812adf74de5ee9e8ad8e081e/blueprints/helper-test)) with a few changes:

- Only generates an integration test (no option for a unit test)
- Adds a flag for generating a class-based modifier and defaults to functional-based (acceptable class flags are: `-s` & `--class`)
- Does not support pre-RFC232 style tests or older versions of Mocha

### Fixes
[#5 Unknown Blueprint: functional-modifier](https://github.com/ember-modifier/ember-modifier/issues/5)

### Open Questions
Whereas a `helper` will return a value by default, is there a sensible "default" modifier behavior we could add? That way we could have a semi-meaningful test from the blueprint. 

I thought about adding an attribute or something, but that didn't feel like something you would use a modifier for. 🤔 