### PR TITLE
makeFunctionalModifier -> modifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ import { modifier } from 'ember-modifier';
 
 const { random, round } = Math;
 
-export default makeFunctionalModifier(element => {
+export default modifier(element => {
   const id = setInterval(() => {
     const top = round(random() * 500);
     const left = round(random() * 500);


### PR DESCRIPTION
Copying and pasting the code from functional w/ clean up example, I noticed that `makeFunctionalModifier` was undefined, and it looks like it's been renamed to just `modifier`.