### PR TITLE
Simplify the teardown APIs

### DIFF
--- a/addon/-private/class/modifier-manager.ts
+++ b/addon/-private/class/modifier-manager.ts
@@ -3,11 +3,7 @@ import { capabilities } from '@ember/modifier';
 import { set } from '@ember/object';
 import { schedule } from '@ember/runloop';
 
-import ClassBasedModifier, {
-  DESTROYING,
-  DESTROYED,
-  InTeardown,
-} from './modifier';
+import ClassBasedModifier, { DESTROYING, DESTROYED } from './modifier';
 import { ModifierArgs } from 'ember-modifier/-private/interfaces';
 
 function scheduleDestroy(modifier: ClassBasedModifier, meta: Ember.Meta): void {
@@ -48,12 +44,8 @@ class ClassBasedModifierManager {
     instance.didReceiveArguments();
   }
 
-  // Uses `InTeardown<ClassBasedModifier>` to correctly model the type of
-  // `element` at this point in the lifecycle. This is safe because this manager
-  // is what *defines* that lifecycle behavior.
-  destroyModifier(instance: InTeardown<ClassBasedModifier>): void {
+  destroyModifier(instance: ClassBasedModifier): void {
     instance.willRemove();
-    instance.element = null;
 
     if (instance[DESTROYING]) {
       return;

--- a/addon/-private/class/modifier.ts
+++ b/addon/-private/class/modifier.ts
@@ -44,7 +44,8 @@ export default class ClassBasedModifier<
    * @warning `element` is ***not*** available during `constructor` or
    *   `willDestroy`.
    */
-  // SAFETY: this is managed correctly by the class-based modifier.
+  // SAFETY: this is managed correctly by the class-based modifier. It is not
+  // available during the `constructor`.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   element: Element = null as any;
 
@@ -80,6 +81,10 @@ export default class ClassBasedModifier<
   /**
    * Called when the DOM element is about to be destroyed; use for removing
    * event listeners on the element and other similar clean-up tasks.
+   *
+   * @deprecated since 2.0.0: prefer to use `willDestroy`, since both it and
+   *   `willRemove` can perform all the same operations, including on the
+   *   `element`.
    */
   willRemove(): void {
     /* no op, for subclassing */
@@ -87,13 +92,7 @@ export default class ClassBasedModifier<
 
   /**
    * Called when the modifier itself is about to be destroyed; use for teardown
-   * code. Called after `willRemove`. The element is no longer available at this
-   * point (i.e. its value is `null` during teardown).
-   *
-   * @note TypeScript users can import the `InTeardown` type utility for safely
-   *   handling `null` here; see [the note in the README for details][README].
-   *
-   * [README]: https://github.com/ember-modifier/ember-modifier#lifecycle-hooks-and-types
+   * code. Called after `willRemove`.
    */
   willDestroy(): void {
     /* no op, for subclassing */
@@ -107,29 +106,5 @@ export default class ClassBasedModifier<
     return this[DESTROYED];
   }
 }
-
-/**
- * A utility for extra type safety in the `willDestroy` lifecycle hook in
- * classes which extend `ClassBasedModifier`: it types `element` as `null`.
- *
- * ## Usage
- *
- * ```ts
- * import Modifier, { InTeardown } from 'ember-modifier';
- *
- * function doSomethingWithElement(el: Element) {
- *   // ...
- * }
- *
- * export default class CorrectlyTypedModifier extends Modifier {
- *   willRemove(this: InTeardown<CorrectlyTypedModifier>) {
- *     doSomethingWithElement(this.element); // TYPE ERROR!
- *   }
- * }
- * ```
- */
-export type InTeardown<M extends ClassBasedModifier> = Omit<M, 'element'> & {
-  element: null;
-};
 
 setModifierManager(() => Manager, ClassBasedModifier);

--- a/addon/index.ts
+++ b/addon/index.ts
@@ -1,3 +1,3 @@
-export { default, InTeardown } from './-private/class/modifier';
+export { default } from './-private/class/modifier';
 export { default as modifier } from './-private/functional/modifier';
 export { ModifierArgs } from './-private/interfaces';

--- a/tests/integration/modifiers/class-modifier-test.ts
+++ b/tests/integration/modifiers/class-modifier-test.ts
@@ -451,7 +451,7 @@ export function testHooks(factory: Factory): void {
     insert: false,
     update: false,
     destroy: true,
-    element: false,
+    element: true,
     factory,
   });
 

--- a/types/modifier-test.ts
+++ b/types/modifier-test.ts
@@ -1,6 +1,6 @@
 import { expectTypeOf } from 'expect-type';
 
-import Modifier, { modifier, InTeardown, ModifierArgs } from 'ember-modifier';
+import Modifier, { modifier, ModifierArgs } from 'ember-modifier';
 
 // --- function modifier --- //
 expectTypeOf(modifier).toEqualTypeOf<
@@ -32,33 +32,3 @@ expectTypeOf<ModifierArgs>().toEqualTypeOf<{
   named: Record<string, unknown>;
   positional: unknown[];
 }>();
-
-// `InTeardown<Modifier>` should be identical to `Modifier` *except* for the
-// definition of `element`.
-expectTypeOf<InTeardown<Modifier>['element']>().not.toEqualTypeOf<
-  Modifier['element']
->();
-expectTypeOf<InTeardown<Modifier>['element']>().toEqualTypeOf<null>();
-
-expectTypeOf<InTeardown<Modifier>['args']>().toEqualTypeOf<Modifier['args']>();
-expectTypeOf<InTeardown<Modifier>['didReceiveArguments']>().toEqualTypeOf<
-  Modifier['didReceiveArguments']
->();
-expectTypeOf<InTeardown<Modifier>['didUpdateArguments']>().toEqualTypeOf<
-  Modifier['didUpdateArguments']
->();
-expectTypeOf<InTeardown<Modifier>['didInstall']>().toEqualTypeOf<
-  Modifier['didInstall']
->();
-expectTypeOf<InTeardown<Modifier>['willRemove']>().toEqualTypeOf<
-  Modifier['willRemove']
->();
-expectTypeOf<InTeardown<Modifier>['willDestroy']>().toEqualTypeOf<
-  Modifier['willDestroy']
->();
-expectTypeOf<InTeardown<Modifier>['isDestroying']>().toEqualTypeOf<
-  Modifier['isDestroying']
->();
-expectTypeOf<InTeardown<Modifier>['isDestroyed']>().toEqualTypeOf<
-  Modifier['isDestroyed']
->();


### PR DESCRIPTION
Resolves #29

- make `this.element` available during `willDestroy`
- deprecate the `willRemove` hook, since it's redundant
- remove the now-unnecessary `InTeardown` utility type
- update the docs

Note that this is *not* a breaking change: the previous behavior will continue to work as expected. The deprecation introduced here will remain *until* a 3.0, whatever the trigger for that release may be (e.g. when Node 10 LTS reaches end of life).