### PR TITLE
Avoid issuing a deprecation during destruction on Ember 3.20+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ env:
 branches:
   only:
     - master
+    - v1.x
     # npm version tags
     - /^v\d+\.\d+\.\d+/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 ---
 language: node_js
 node_js:
-  # we recommend testing addons with the same minimum supported node version as Ember CLI
-  # so that your addon works for all apps
-  - "8"
+  - "12"
 
 sudo: false
 dist: trusty
@@ -35,6 +33,7 @@ jobs:
 
     - stage: "Tests"
       name: "Tests"
+      node_js: "8"
       install:
         - yarn install --non-interactive
       script:
@@ -51,6 +50,8 @@ jobs:
     - stage: "Additional Tests"
       env: EMBER_TRY_SCENARIO=ember-lts-3.4
     - env: EMBER_TRY_SCENARIO=ember-lts-3.8
+    - env: EMBER_TRY_SCENARIO=ember-lts-3.12
+    - env: EMBER_TRY_SCENARIO=ember-lts-3.16
     - env: EMBER_TRY_SCENARIO=ember-release
     - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -37,6 +37,30 @@ module.exports = async function() {
         },
       },
       {
+        name: 'ember-lts-3.12',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.12.0',
+          },
+        },
+      },
+      {
+        name: 'ember-lts-3.16',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.16.0',
+          },
+        },
+      },
+      {
+        name: 'ember-lts-3.20',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.20.0',
+          },
+        },
+      },
+      {
         name: 'ember-release',
         npm: {
           devDependencies: {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "ember-cli-is-package-missing": "^1.0.0",
     "ember-cli-normalize-entity-name": "^1.0.0",
     "ember-cli-string-utils": "^1.1.0",
+    "ember-compatibility-helpers": "^1.2.1",
     "ember-modifier-manager-polyfill": "^1.2.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3462,6 +3462,15 @@ ember-compatibility-helpers@^1.2.0:
     ember-cli-version-checker "^2.1.1"
     semver "^5.4.1"
 
+ember-compatibility-helpers@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.1.tgz#87c92c4303f990ff455c28ca39fb3ee11441aa16"
+  integrity sha512-6wzYvnhg1ihQUT5yGqnLtleq3Nv5KNv79WhrEuNU9SwR4uIxCO+KpyC7r3d5VI0EM7/Nmv9Nd0yTkzmTMdVG1A==
+  dependencies:
+    babel-plugin-debug-macros "^0.2.0"
+    ember-cli-version-checker "^2.1.1"
+    semver "^5.4.1"
+
 ember-decorators-polyfill@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/ember-decorators-polyfill/-/ember-decorators-polyfill-1.0.6.tgz#93094a1eebfd8d54e85abd941f78bc330dc3f973"


### PR DESCRIPTION
Ideally, this could have just backported the changes from 02ebf5cbb5369506ec23c67da692a659cba6e37c, but unfortunately v1.x of ember-modifier still supports Node 8 (and `ember-destroyable-polyfill` does not).

Instead, this avoids the deprecation (by avoiding the methods that issue the deprecation on the affected versions of Ember). It also ensures that on Ember 3.20 (and eventually users of the non-polyfilled final implementation in Ember 3.22+) _other_ users of ember-destroyable-polyfill **can** use `registerDestructor` and reliably have that invoked.