### PR TITLE
Fix v1.x issue with Ember 3.20.4+.

### DIFF
--- a/addon/-private/class/modifier-manager.js
+++ b/addon/-private/class/modifier-manager.js
@@ -44,6 +44,7 @@ class ClassBasedModifierManager {
       // @ember/destroyable API's `destroy` function (this will
       // ensure that any users _on_ 3.20 that have called
       // `registerDestructor` have their destructors called
+      // eslint-disable-next-line ember/new-module-imports
       Ember.destroy(instance);
     } else {
       meta.setSourceDestroying();
@@ -62,6 +63,7 @@ function scheduleDestroy(modifier, meta) {
   if (!gte('3.20.0-beta.4')) {
     // in 3.20+ we call destroy _early_ (because it is actually
     // the @ember/destroyable's `destroy` API)
+    // eslint-disable-next-line ember/new-module-imports
     Ember.destroy(modifier);
     meta.setSourceDestroyed();
   }

--- a/addon/-private/class/modifier-manager.js
+++ b/addon/-private/class/modifier-manager.js
@@ -9,10 +9,14 @@ import { DESTROYING, DESTROYED } from './modifier';
 class ClassBasedModifierManager {
   capabilities = capabilities('3.13');
 
-  createModifier(factory, args) {
-    let { owner, class: modifier } = factory;
+  constructor(owner) {
+    this.owner = owner;
+  }
 
-    return new modifier(owner, args);
+  createModifier(factory, args) {
+    let Modifier = factory.class;
+
+    return new Modifier(this.owner, args);
   }
   installModifier(instance, element) {
     instance.element = element;
@@ -71,4 +75,4 @@ function scheduleDestroy(modifier, meta) {
   modifier[DESTROYED] = true;
 }
 
-export default new ClassBasedModifierManager();
+export default ClassBasedModifierManager;

--- a/addon/-private/class/modifier.js
+++ b/addon/-private/class/modifier.js
@@ -31,4 +31,4 @@ export default class ClassBasedModifier {
   }
 }
 
-setModifierManager(() => Manager, ClassBasedModifier);
+setModifierManager((owner) => new Manager(owner), ClassBasedModifier);


### PR DESCRIPTION
Prior to this change, we happened to be relying on accidental behavior in Ember. Specifically, that the first argument of `createModifier` would contain the `owner` property. This was not part of the RFC and is not a documented feature. The correct way to obtain the owner has always been by way of the `setModifierManager` API which this commit changes to.

References:

* https://github.com/emberjs/ember.js/pull/19088
* https://github.com/emberjs/rfcs/blob/master/text/0373-Element-Modifier-Managers.md

Fixes https://github.com/ember-modifier/ember-modifier/issues/59