### PR TITLE
Add support for `3.22` modifier capabilities

### DIFF
--- a/addon/-private/class/modifier-manager.ts
+++ b/addon/-private/class/modifier-manager.ts
@@ -33,13 +33,9 @@ export default class ClassBasedModifierManager {
     factoryOrClass: Factory | typeof ClassBasedModifier,
     args: ModifierArgs
   ): ClassBasedModifier {
-    let Modifier: typeof ClassBasedModifier;
-
-    if (isFactory(factoryOrClass)) {
-      Modifier = factoryOrClass.class;
-    } else {
-      Modifier = factoryOrClass;
-    }
+    const Modifier = isFactory(factoryOrClass)
+      ? factoryOrClass.class
+      : factoryOrClass;
 
     const modifier = new Modifier(this.owner, args);
 

--- a/addon/-private/class/modifier-manager.ts
+++ b/addon/-private/class/modifier-manager.ts
@@ -5,23 +5,11 @@ import { destroy, registerDestructor } from '@ember/destroyable';
 
 import ClassBasedModifier from './modifier';
 import { ModifierArgs } from 'ember-modifier/-private/interfaces';
-import { consumeArgs } from '../consume-args';
-
-interface Factory {
-  owner: unknown;
-  class: typeof ClassBasedModifier;
-}
+import { consumeArgs, Factory, isFactory } from '../compat';
 
 function destroyModifier(modifier: ClassBasedModifier): void {
   modifier.willRemove();
   modifier.willDestroy();
-}
-
-function isFactory(
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _factoryOrClass: Factory | unknown
-): _factoryOrClass is Factory {
-  return !gte('3.22.0');
 }
 
 export default class ClassBasedModifierManager {
@@ -30,7 +18,9 @@ export default class ClassBasedModifierManager {
   constructor(private owner: unknown) {}
 
   createModifier(
-    factoryOrClass: Factory | typeof ClassBasedModifier,
+    factoryOrClass:
+      | Factory<typeof ClassBasedModifier>
+      | typeof ClassBasedModifier,
     args: ModifierArgs
   ): ClassBasedModifier {
     const Modifier = isFactory(factoryOrClass)

--- a/addon/-private/compat.ts
+++ b/addon/-private/compat.ts
@@ -1,8 +1,21 @@
 import { ModifierArgs } from 'ember-modifier/-private/interfaces';
+import { gte } from 'ember-compatibility-helpers';
+
+export interface Factory<T> {
+  owner: unknown;
+  class: T;
+}
+
+export function isFactory<T>(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _factoryOrClass: Factory<T> | T
+): _factoryOrClass is Factory<T> {
+  return !gte('3.22.0');
+}
 
 // This is a workaround for a change in the autotracking semantics of the args
 // proxy introduced in `3.22`. Arguments are no longer eagerly consumed, so if
-// you didn’t use an argument, it
+// you didn’t use an argument, it won’t be updated.
 export function consumeArgs({ positional, named }: ModifierArgs): void {
   for (let i = 0; i < positional.length; i++) {
     positional[i];

--- a/addon/-private/consume-args.ts
+++ b/addon/-private/consume-args.ts
@@ -1,0 +1,12 @@
+import { ModifierArgs } from 'ember-modifier/-private/interfaces';
+
+// This is a workaround for a change in the autotracking semantics of the args
+// proxy introduced in `3.22`. Arguments are no longer eagerly consumed, so if
+// you didn’t use an argument, it
+export function consumeArgs({ positional, named }: ModifierArgs): void {
+  for (let i = 0; i < positional.length; i++) {
+    positional[i];
+  }
+
+  Object.values(named);
+}

--- a/addon/-private/functional/modifier-manager.ts
+++ b/addon/-private/functional/modifier-manager.ts
@@ -43,13 +43,9 @@ class FunctionalModifierManager {
   createModifier(
     factoryOrClass: Factory | FunctionalModifier
   ): FunctionalModifier {
-    let Modifier: FunctionalModifier;
-
-    if (isFactory(factoryOrClass)) {
-      Modifier = factoryOrClass.class;
-    } else {
-      Modifier = factoryOrClass;
-    }
+    const Modifier = isFactory(factoryOrClass)
+      ? factoryOrClass.class
+      : factoryOrClass;
 
     // This looks superfluous, but this is creating a new instance
     // of a function -- this is important so that each instance of the

--- a/addon/-private/functional/modifier-manager.ts
+++ b/addon/-private/functional/modifier-manager.ts
@@ -2,11 +2,7 @@ import { capabilities } from '@ember/modifier';
 import { gte } from 'ember-compatibility-helpers';
 import { FunctionalModifier } from './modifier';
 import { ModifierArgs } from '../interfaces';
-import { consumeArgs } from '../consume-args';
-
-interface Factory {
-  class: FunctionalModifier;
-}
+import { consumeArgs, Factory, isFactory } from '../compat';
 
 const MODIFIER_ELEMENTS = new WeakMap();
 const MODIFIER_TEARDOWNS: WeakMap<FunctionalModifier, unknown> = new WeakMap();
@@ -30,18 +26,11 @@ function setup(
   MODIFIER_TEARDOWNS.set(modifier, teardown);
 }
 
-function isFactory(
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _factoryOrClass: Factory | unknown
-): _factoryOrClass is Factory {
-  return !gte('3.22.0');
-}
-
 class FunctionalModifierManager {
   capabilities = capabilities(gte('3.22.0') ? '3.22' : '3.13');
 
   createModifier(
-    factoryOrClass: Factory | FunctionalModifier
+    factoryOrClass: Factory<FunctionalModifier> | FunctionalModifier
   ): FunctionalModifier {
     const Modifier = isFactory(factoryOrClass)
       ? factoryOrClass.class

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "ember-cli-normalize-entity-name": "^1.0.0",
     "ember-cli-string-utils": "^1.1.0",
     "ember-cli-typescript": "^3.1.3",
+    "ember-compatibility-helpers": "^1.2.4",
     "ember-destroyable-polyfill": "^2.0.2",
     "ember-modifier-manager-polyfill": "^1.2.0"
   },
@@ -73,7 +74,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.0",
-    "ember-source": "~3.20.2",
+    "ember-source": "~3.22.0",
     "ember-source-channel-url": "^2.0.1",
     "ember-template-lint": "^2.9.1",
     "ember-try": "^1.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5345,6 +5345,16 @@ ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.0, ember-co
     ember-cli-version-checker "^2.1.1"
     semver "^5.4.1"
 
+ember-compatibility-helpers@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.4.tgz#70e0fef7048969141626eed6006f3880df612cd1"
+  integrity sha512-qjzQVtogyYJrSs6I4DuyCDwDCaj5JWBVNPoZDZBk8pt7caNoN0eBYRYJdin95QKaNMQODxTLPWaI4UUDQ1YWhg==
+  dependencies:
+    babel-plugin-debug-macros "^0.2.0"
+    ember-cli-version-checker "^5.1.1"
+    fs-extra "^9.1.0"
+    semver "^5.4.1"
+
 ember-decorators-polyfill@^1.0.6:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ember-decorators-polyfill/-/ember-decorators-polyfill-1.1.5.tgz#49203c302ea4486618ba4866923ec657cf2c9f3d"
@@ -5453,10 +5463,10 @@ ember-source-channel-url@^2.0.1:
   dependencies:
     got "^8.0.1"
 
-ember-source@~3.20.2:
-  version "3.20.2"
-  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.20.2.tgz#c8ea4fd43230ae91e9362c3136b37ed9bdd91c2a"
-  integrity sha512-9uPBKF7B7doz6u0z+0vBczGqaAVpcGmjqQkZdtf0C0aYY7NXRYDMZrx7vudy5DRhP13Ryo4rjZhlcRgbFPR44w==
+ember-source@~3.22.0:
+  version "3.22.2"
+  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.22.2.tgz#dce9b9b1c1559aa90488d3a343a2b7628a0f022a"
+  integrity sha512-P8IQkVd4iXDf0y+2PCEnCJDxZTOyiU1vfebzvXbW6NnoDsOoVP0xvGgoHV2bGFoskCMe4ViYNjuHirfjWvr5CA==
   dependencies:
     "@babel/helper-module-imports" "^7.8.3"
     "@babel/plugin-transform-block-scoping" "^7.8.3"
@@ -6574,6 +6584,16 @@ fs-extra@^9.0.0:
     graceful-fs "^4.2.0"
     jsonfile "^6.0.1"
     universalify "^1.0.0"
+
+fs-extra@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
+  integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
+  dependencies:
+    at-least-node "^1.0.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
 
 fs-merger@^3.1.0:
   version "3.1.0"
@@ -11953,6 +11973,11 @@ universalify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-1.0.0.tgz#b61a1da173e8435b2fe3c67d29b9adf8594bd16d"
   integrity sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==
+
+universalify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
+  integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Fixes #75, based on discussions from https://github.com/ember-modifier/ember-modifier/pull/63#issuecomment-815908201.

### Changes

- Bump capabilities for Ember `>=v3.22`
- Add support for creating modifiers without factories in Ember `>=v3.22`
- Eagerly consume arguments in Ember `>=v3.22` to preserve backwards compatibility.

  Newer versions require you to actually use an argument to entangle it in autotracking and enable updates. Previously, this was not a requirement. The manager will eagerly consume all arguments to avoid introducing a breaking change until a suitable transition path is made available.

### Alternatives

We can avoid the type-hackery by using multiple versioned managers and exporting the correct manager at build time, like so: https://github.com/ember-modifier/ember-modifier/compare/master...sandydoo:upgrade-manager-capabilities-with-versioned-managers
This avoids the whole issue with `createModifier` having a different type signature in `>=v3.22`. I’m not sure which is better. I feel like the current PR is more in line with what I’ve seen in the Ember and Glimmer repos, _but_ using multiple managers produces perfect code once compiled 🤷