### PR TITLE
Improve logic in `removeEventListener()` from examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ export default class OnModifier extends Modifier {
   }
 
   removeEventListener() {
-    let [event, handler] = this.args.positional;
+    let { event, handler } = this;
 
     if (event && handler) {
       this.element.removeEventListener(event, handler);


### PR DESCRIPTION
Improve logic in `removeEventListener()` from examples by reusing the properties `event` and `handler` stored in the class instead of using `this.args.positional` (which could potentially give us new and different parameters from what has been stored/set up before).

Relates to this comment:
https://github.com/ember-modifier/ember-modifier/issues/21#issuecomment-853204785

> * The modifier is called a first time, everything runs correctly.
> * The arguments are updated, `didReceiveArguments()` gets called.
> * `removeEventListener()` gets called, we might actually prefer to use/remove the `event` and `handler` already stored on `this`
> * `addEventListener()` will run using the updated arguments.

Undo and improve what has been done in:
https://github.com/ember-modifier/ember-modifier/pull/22
