### PR TITLE
Freshen all other dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "eslint-plugin-ember": "^10.5.7",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.0.0",
-    "expect-type": "^0.7.3",
+    "expect-type": "^0.13.0",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6010,10 +6010,10 @@ expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   dependencies:
     homedir-polyfill "^1.0.1"
 
-expect-type@^0.7.3:
-  version "0.7.11"
-  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-0.7.11.tgz#e6d4ba69aa5db383d4c5c1dcc7b439e72480fc30"
-  integrity sha512-wh/Hpbwsumt/yu2gQyw5PLBpVQaWL4j9i2bKrGNaZxyLGfvhRWwuxLoeCmQHCKYFMild0lp8rK+H9haTW3biQg==
+expect-type@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-0.13.0.tgz#916646a7a73f3ee77039a634ee9035efe1876eb2"
+  integrity sha512-CclevazQfrqo8EvbLPmP7osnb1SZXkw47XPPvUUpeMz4HuGzDltE7CaIt3RLyT9UQrwVK/LDn+KVcC0hcgjgDg==
 
 express@^4.10.7, express@^4.17.1:
   version "4.17.1"


### PR DESCRIPTION
Update every `package.json` entry to latest (except `ember-cli-htmlbars`, which is not yet ready to go to 6.0.0 for reasons related to #101 and #102).