### PR TITLE
chore: run TS compat independent of tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
     name: Type checking - ${{ matrix.typescript-scenario }}
     runs-on: ubuntu-latest
     continue-on-error: true
-    needs: test
+    needs: lint
 
     strategy:
       fail-fast: true


### PR DESCRIPTION
Previously we were gating the TS compatibility tests on having had at least one successful test run for the Ember test suite, but there's no reason to do that. We really only want to wait on `lint`, since that is our gate for making sure things type check against the current target v. of TypeScript.