### PR TITLE
Breaking: remove deprecated willRemove hook

### DIFF
--- a/addon/-private/class/modifier-manager.ts
+++ b/addon/-private/class/modifier-manager.ts
@@ -8,7 +8,6 @@ import { ModifierArgs } from 'ember-modifier/-private/interfaces';
 import { consumeArgs, Factory, isFactory } from '../compat';
 
 function destroyModifier(modifier: ClassBasedModifier): void {
-  modifier.willRemove();
   modifier.willDestroy();
 }
 

--- a/addon/-private/class/modifier.ts
+++ b/addon/-private/class/modifier.ts
@@ -69,18 +69,6 @@ export default class ClassBasedModifier<
   }
 
   /**
-   * Called when the DOM element is about to be destroyed; use for removing
-   * event listeners on the element and other similar clean-up tasks.
-   *
-   * @deprecated since 2.0.0: prefer to use `willDestroy`, since both it and
-   *   `willRemove` can perform all the same operations, including on the
-   *   `element`.
-   */
-  willRemove(): void {
-    /* no op, for subclassing */
-  }
-
-  /**
    * Called when the modifier itself is about to be destroyed; use for teardown
    * code. Called after `willRemove`.
    */

--- a/tests/integration/modifiers/class-modifier-test.ts
+++ b/tests/integration/modifiers/class-modifier-test.ts
@@ -61,7 +61,7 @@ function testHook({
 
             assert.strictEqual(
               instance.isDestroying,
-              name === 'willDestroy' || name === 'willRemove',
+              name === 'willDestroy',
               'isDestroying'
             );
             assert.strictEqual(instance.isDestroyed, false, 'isDestroyed');
@@ -385,7 +385,7 @@ function testHooksOrdering(factory: Factory): void {
 
       assert.step('destroy');
 
-      await assertHooks(['willRemove', 'willDestroy'], () => {
+      await assertHooks(['willDestroy'], () => {
         this.set('isShowing', false);
       });
 
@@ -438,15 +438,6 @@ function testHooks(factory: Factory): void {
   });
 
   testHook({
-    name: 'willRemove',
-    insert: false,
-    update: false,
-    destroy: true,
-    element: true,
-    factory,
-  });
-
-  testHook({
     name: 'willDestroy',
     insert: false,
     update: false,
@@ -481,10 +472,6 @@ module(
 
           didInstall(): void {
             callback('didInstall', this);
-          }
-
-          willRemove(): void {
-            callback('willRemove', this);
           }
 
           willDestroy(): void {

--- a/type-tests/modifier-test.ts
+++ b/type-tests/modifier-test.ts
@@ -22,7 +22,6 @@ expectTypeOf<Modifier['element']>().toEqualTypeOf<Element>();
 expectTypeOf<Modifier['didReceiveArguments']>().toEqualTypeOf<() => void>();
 expectTypeOf<Modifier['didUpdateArguments']>().toEqualTypeOf<() => void>();
 expectTypeOf<Modifier['didInstall']>().toEqualTypeOf<() => void>();
-expectTypeOf<Modifier['willRemove']>().toEqualTypeOf<() => void>();
 expectTypeOf<Modifier['willDestroy']>().toEqualTypeOf<() => void>();
 expectTypeOf<Modifier['isDestroying']>().toEqualTypeOf<boolean>();
 expectTypeOf<Modifier['isDestroyed']>().toEqualTypeOf<boolean>();


### PR DESCRIPTION
Honestly, I meant to remove this for 3.0.0, but hey: now folks have a longer time to migrate. 😂 