### PR TITLE
Breaking: clean up type parameters.

### DIFF
--- a/addon/-private/functional/modifier.ts
+++ b/addon/-private/functional/modifier.ts
@@ -3,9 +3,9 @@ import FunctionalModifierManager from './modifier-manager';
 import { ModifierArgs } from '../interfaces';
 
 export type FunctionalModifier<
+  E extends Element = Element,
   P extends ModifierArgs['positional'] = ModifierArgs['positional'],
-  N extends ModifierArgs['named'] = ModifierArgs['named'],
-  E extends Element = Element
+  N extends ModifierArgs['named'] = ModifierArgs['named']
 > = (element: E, positional: P, named: N) => unknown;
 
 /**
@@ -24,9 +24,9 @@ export type FunctionalModifier<
  * @param fn The function which defines the modifier.
  */
 export default function modifier<
-  E extends Element = Element,
-  P extends ModifierArgs['positional'] = ModifierArgs['positional'],
-  N extends ModifierArgs['named'] = ModifierArgs['named']
->(fn: FunctionalModifier<P, N, E>): unknown {
+  E extends Element,
+  P extends ModifierArgs['positional'],
+  N extends ModifierArgs['named']
+>(fn: FunctionalModifier<E, P, N>): unknown {
   return setModifierManager(() => FunctionalModifierManager, fn);
 }


### PR DESCRIPTION
- Fix the order of the type parameters defining `FunctionalModifier`. Most consumers will not be affected by this, but anyone who imported the type and used it directly *will* be.
- Remove the unnecessary generic from the `ModifierArgs` interface. This was never being used anywhere, so this is *not* a breaking change, and could theoretically be backported... but since it wasn't being used anywhere, there's no point.
- Remove type param defaults from function-based modifier. These are not strictly necessary, and this can in fact be supplied safely backwards-compatibility (as the type test suite confirms), because there was no situation in which it was ever *required* to specify these previously, so backporting would also be useless.