### PR TITLE
Actually remove `<N>` from `ModifierArgs`

### DIFF
--- a/addon/-private/interfaces.ts
+++ b/addon/-private/interfaces.ts
@@ -1,6 +1,6 @@
-export interface ModifierArgs<N = unknown> {
+export interface ModifierArgs {
   /** Positional arguments to a modifier, `{{foo @bar this.baz}}` */
   positional: unknown[];
   /** Named arguments to a modifier, `{{foo bar=this.baz}}` */
-  named: Record<string, N>;
+  named: Record<string, unknown>;
 }


### PR DESCRIPTION
This was meant to be included in 6f6b443, and was just missed in constructing the commit!