### PR TITLE
Add TypeScript 4.5 to testing matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,7 @@ jobs:
           typescript-4.2,
           typescript-4.3,
           typescript-4.4,
+          typescript-4.5,
           typescript-next,
         ]
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Compatibility
 
 This project follows the current draft of [the Semantic Versioning for TypeScript Types][semver] proposal.
 
-- **Currently supported TypeScript versions:** v4.2, v4.3, and v4.4
+- **Currently supported TypeScript versions:** v4.2, v4.3, v4.4, and v4.5
 - **Compiler support policy:** [simple majors][sm]
 - **Public API:** all published types not in a `-private` module are public
 

--- a/config/ember-try-typescript.js
+++ b/config/ember-try-typescript.js
@@ -21,6 +21,12 @@ module.exports = {
       },
     },
     {
+      name: 'typescript-4.5',
+      npm: {
+        typescript: '~4.5',
+      },
+    },
+    {
       name: 'typescript-next',
       allowedToFail: true,
       npm: {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "release-it": "^14.11.6",
     "release-it-lerna-changelog": "^4.0.1",
     "rimraf": "^3.0.2",
-    "typescript": "^4.4.4",
+    "typescript": "^4.5.2",
     "webpack": "^5.58.2"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12409,10 +12409,10 @@ typescript-memoize@^1.0.0-alpha.3:
   resolved "https://registry.yarnpkg.com/typescript-memoize/-/typescript-memoize-1.0.1.tgz#0a8199aa28f6fe18517f6e9308ef7bfbe9a98d59"
   integrity sha512-oJNge1qUrOK37d5Y6Ly2txKeuelYVsFtNF6U9kXIN7juudcQaHJQg2MxLOy0CqtkW65rVDYuTCOjnSIVPd8z3w==
 
-typescript@^4.4.4:
-  version "4.4.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
-  integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
+typescript@^4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.2.tgz#8ac1fba9f52256fdb06fb89e4122fa6a346c2998"
+  integrity sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
TypeScript v4.5 was released on November 17th, 2021, this is just to keep up with recent changes and have some sanity check.