### PR TITLE
Support `Signature` types for modifiers

### DIFF
--- a/addon/-private/class/modifier-manager.ts
+++ b/addon/-private/class/modifier-manager.ts
@@ -4,14 +4,14 @@ import { set } from '@ember/object';
 import { destroy, registerDestructor } from '@ember/destroyable';
 
 import ClassBasedModifier from './modifier';
-import { ModifierArgs } from 'ember-modifier/-private/interfaces';
+import { ArgsFor, ElementFor } from 'ember-modifier/-private/signature';
 import { consumeArgs, Factory, isFactory } from '../compat';
 
-function destroyModifier(modifier: ClassBasedModifier): void {
+function destroyModifier<S>(modifier: ClassBasedModifier<S>): void {
   modifier.willDestroy();
 }
 
-export default class ClassBasedModifierManager {
+export default class ClassBasedModifierManager<S> {
   capabilities = capabilities(gte('3.22.0') ? '3.22' : '3.13');
 
   constructor(private owner: unknown) {}
@@ -20,8 +20,8 @@ export default class ClassBasedModifierManager {
     factoryOrClass:
       | Factory<typeof ClassBasedModifier>
       | typeof ClassBasedModifier,
-    args: ModifierArgs
-  ): ClassBasedModifier {
+    args: ArgsFor<S>
+  ): ClassBasedModifier<S> {
     const Modifier = isFactory(factoryOrClass)
       ? factoryOrClass.class
       : factoryOrClass;
@@ -34,9 +34,9 @@ export default class ClassBasedModifierManager {
   }
 
   installModifier(
-    instance: ClassBasedModifier,
-    element: Element,
-    args: ModifierArgs
+    instance: ClassBasedModifier<S>,
+    element: ElementFor<S>,
+    args: ArgsFor<S>
   ): void {
     instance.element = element;
 
@@ -48,7 +48,7 @@ export default class ClassBasedModifierManager {
     instance.didInstall();
   }
 
-  updateModifier(instance: ClassBasedModifier, args: ModifierArgs): void {
+  updateModifier(instance: ClassBasedModifier<S>, args: ArgsFor<S>): void {
     // TODO: this should be an args proxy
     set(instance, 'args', args);
 

--- a/addon/-private/class/modifier.ts
+++ b/addon/-private/class/modifier.ts
@@ -1,8 +1,8 @@
 import { setOwner } from '@ember/application';
 import { setModifierManager } from '@ember/modifier';
 import Manager from './modifier-manager';
-import { ModifierArgs } from 'ember-modifier/-private/interfaces';
 import { isDestroying, isDestroyed } from '@ember/destroyable';
+import { ElementFor, ArgsFor, DefaultSignature } from '../signature';
 
 /**
  * A base class for modifiers which need more capabilities than function-based
@@ -18,15 +18,13 @@ import { isDestroying, isDestroyed } from '@ember/destroyable';
  * values they access will be added to the modifier, and the modifier will
  * update if any of those values change.
  */
-export default class ClassBasedModifier<
-  Args extends ModifierArgs = ModifierArgs
-> {
+export default class ClassBasedModifier<S = DefaultSignature> {
   /**
    * The arguments passed to the modifier. `args.positional` is an array of
    * positional arguments, and `args.named` is an object containing the named
    * arguments.
    */
-  readonly args: Args;
+  readonly args: ArgsFor<S>;
 
   /**
    * The element the modifier is applied to.
@@ -37,9 +35,9 @@ export default class ClassBasedModifier<
   // SAFETY: this is managed correctly by the class-based modifier. It is not
   // available during the `constructor`.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  element: Element = null as any;
+  element: ElementFor<S> = null as any;
 
-  constructor(owner: unknown, args: Args) {
+  constructor(owner: unknown, args: ArgsFor<S>) {
     setOwner(this, owner);
     this.args = args;
   }

--- a/addon/-private/compat.ts
+++ b/addon/-private/compat.ts
@@ -1,5 +1,5 @@
-import { ModifierArgs } from './interfaces';
 import { gte } from 'ember-compatibility-helpers';
+import { ArgsFor } from './signature';
 
 export interface Factory<T> {
   owner: unknown;
@@ -27,10 +27,10 @@ const noop = (): void => {};
  * avoid introducing a breaking change until a suitable transition path is made
  * available.
  */
-let consumeArgs: (args: ModifierArgs) => void = noop;
+let consumeArgs: (args: ArgsFor<any>) => void = noop;
 
 if (gte('3.22.0')) {
-  consumeArgs = function ({ positional, named }) {
+  consumeArgs = function ({ positional, named }: ArgsFor<any>) {
     for (let i = 0; i < positional.length; i++) {
       positional[i];
     }

--- a/addon/-private/interfaces.d.ts
+++ b/addon/-private/interfaces.d.ts
@@ -1,6 +1,0 @@
-export interface ModifierArgs {
-  /** Positional arguments to a modifier, `{{foo @bar this.baz}}` */
-  positional: unknown[];
-  /** Named arguments to a modifier, `{{foo bar=this.baz}}` */
-  named: Record<string, unknown>;
-}

--- a/addon/-private/signature.ts
+++ b/addon/-private/signature.ts
@@ -1,0 +1,55 @@
+/**
+ * @deprecated use a `Signature` instead (see the README for details).
+ */
+export interface ModifierArgs {
+  /** Positional arguments to a modifier, `{{foo @bar this.baz}}` */
+  positional: unknown[];
+  /** Named arguments to a modifier, `{{foo bar=this.baz}}` */
+  named: Record<string, unknown>;
+}
+
+// --- Type utilities for use with Signature types --- //
+
+/** @private */
+export type ElementFor<S> = 'Element' extends keyof S
+  ? S['Element'] extends Element
+    ? S['Element']
+    : Element
+  : Element;
+
+type DefaultPositional = unknown[];
+
+/** @private */
+export type PositionalArgs<S> = 'Args' extends keyof S
+  ? 'Positional' extends keyof S['Args']
+    ? S['Args']['Positional'] extends unknown[]
+      ? S['Args']['Positional']
+      : DefaultPositional
+    : DefaultPositional
+  : 'positional' extends keyof S
+  ? S['positional']
+  : DefaultPositional;
+
+type DefaultNamed = Record<string, unknown>;
+
+/** @private */
+export type NamedArgs<S> = 'Args' extends keyof S
+  ? 'Named' extends keyof S['Args']
+    ? S['Args']['Named'] extends Record<string, unknown>
+      ? S['Args']['Named']
+      : DefaultNamed
+    : DefaultNamed
+  : 'named' extends keyof S
+  ? S['named']
+  : DefaultNamed;
+
+/** @private */
+export interface DefaultSignature {
+  Element: Element;
+}
+
+/** @private */
+export interface ArgsFor<S> {
+  named: NamedArgs<S>;
+  positional: PositionalArgs<S>;
+}

--- a/addon/index.ts
+++ b/addon/index.ts
@@ -1,3 +1,6 @@
 export { default } from './-private/class/modifier';
-export { default as modifier } from './-private/functional/modifier';
-export type { ModifierArgs } from './-private/interfaces';
+export {
+  default as modifier,
+  FunctionBasedModifier,
+} from './-private/functional/modifier';
+export type { ModifierArgs, ArgsFor } from './-private/signature';

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@types/ember__modifier": "^4.0.0",
     "@types/ember-qunit": "~5.0.0",
     "@types/ember-resolver": "^5.0.10",
+    "@types/ember__debug": "~4.0.1",
     "@types/ember__test-helpers": "^2.0.2",
     "@types/qunit": "^2.11.2",
     "@types/rsvp": "^4.0.4",

--- a/tests/integration/modifiers/functional-modifier-test.ts
+++ b/tests/integration/modifiers/functional-modifier-test.ts
@@ -90,7 +90,9 @@ module('Integration | Modifiers | functional modifier', function (hooks) {
 
       this.registerModifier(
         'songbird',
-        modifier(() => callCount++)
+        modifier(() => {
+          callCount++;
+        })
       );
 
       await render(hbs`<h1 {{songbird this.value}}>Hello</h1>`);

--- a/type-tests/modifier-test.ts
+++ b/type-tests/modifier-test.ts
@@ -1,16 +1,20 @@
 import { expectTypeOf } from 'expect-type';
 
 import Modifier, { modifier, ModifierArgs } from 'ember-modifier';
+import { FunctionBasedModifier } from 'ember-modifier/-private/functional/modifier';
 
 // --- function modifier --- //
-expectTypeOf(modifier).toEqualTypeOf<
+expectTypeOf(modifier).toMatchTypeOf<
   (
-    callback: (
+    fn: (
       element: Element,
       positional: unknown[],
       named: Record<string, unknown>
-    ) => unknown
-  ) => unknown
+    ) => void | (() => void)
+  ) => FunctionBasedModifier<{
+    Args: { Named: Record<string, unknown>; Positional: unknown[] };
+    Element: Element;
+  }>
 >();
 
 // --- class-based modifier --- //
@@ -44,11 +48,142 @@ const narrowerFn = modifier(
 );
 
 // Additionally, the type of the resulting modifier should be as we expect.
-expectTypeOf(narrowerFn).toEqualTypeOf<unknown>();
+expectTypeOf(narrowerFn).toEqualTypeOf<
+  FunctionBasedModifier<{
+    Args: {
+      Named: Record<Foo, number>;
+      Positional: [string];
+    };
+    Element: HTMLIFrameElement;
+  }>
+>();
+
+interface TestElementOnly {
+  Element: HTMLCanvasElement;
+}
+
+const elementOnly = modifier<TestElementOnly>((el, pos, named) => {
+  expectTypeOf(el).toEqualTypeOf<HTMLCanvasElement>();
+  expectTypeOf(pos).toEqualTypeOf<unknown[]>();
+  expectTypeOf(named).toEqualTypeOf<Record<string, unknown>>();
+});
+
+expectTypeOf(elementOnly).toEqualTypeOf<
+  FunctionBasedModifier<{
+    Element: HTMLCanvasElement;
+  }>
+>();
+
+interface NamedArgsOnly {
+  Args: {
+    Named: {
+      name: string;
+      age?: number;
+    };
+  };
+}
+
+const namedArgsOnly = modifier<NamedArgsOnly>((el, pos, named) => {
+  expectTypeOf(el).toEqualTypeOf<Element>();
+  expectTypeOf(pos).toEqualTypeOf<unknown[]>();
+  expectTypeOf(named).toEqualTypeOf<NamedArgsOnly['Args']['Named']>();
+});
+
+expectTypeOf(namedArgsOnly).toEqualTypeOf<
+  FunctionBasedModifier<{
+    Element: Element;
+    Args: {
+      Named: NamedArgsOnly['Args']['Named'];
+      Positional: unknown[];
+    };
+  }>
+>();
+
+interface PositionalArgsOnly {
+  Args: {
+    Positional: [name: string, age: number];
+  };
+}
+
+const positionalArgsOnly = modifier<PositionalArgsOnly>((el, pos, named) => {
+  expectTypeOf(el).toEqualTypeOf<Element>();
+  expectTypeOf(pos).toEqualTypeOf<PositionalArgsOnly['Args']['Positional']>();
+  expectTypeOf(named).toEqualTypeOf<Record<string, unknown>>();
+});
+
+expectTypeOf(positionalArgsOnly).toEqualTypeOf<
+  FunctionBasedModifier<{
+    Element: Element;
+    Args: {
+      Named: Record<string, unknown>;
+      Positional: PositionalArgsOnly['Args']['Positional'];
+    };
+  }>
+>();
+
+interface ArgsOnly {
+  Args: {
+    Named: {
+      when: boolean;
+    };
+    Positional: [callback: () => unknown];
+  };
+}
+
+const argsOnly = modifier<ArgsOnly>((el, pos, named) => {
+  expectTypeOf(el).toEqualTypeOf<Element>();
+  expectTypeOf(pos).toEqualTypeOf<ArgsOnly['Args']['Positional']>();
+  expectTypeOf(named).toEqualTypeOf<ArgsOnly['Args']['Named']>();
+});
+
+expectTypeOf(argsOnly).toEqualTypeOf<
+  FunctionBasedModifier<{
+    Element: Element;
+    Args: ArgsOnly['Args'];
+  }>
+>();
+
+interface Full {
+  Element: HTMLElement;
+  Args: {
+    Named: {
+      to: string;
+      onTarget?: string;
+    };
+    Positional: [prop: string];
+  };
+}
+
+const full = modifier<Full>((el, pos, named) => {
+  expectTypeOf(el).toEqualTypeOf<Full['Element']>();
+  expectTypeOf(pos).toEqualTypeOf<Full['Args']['Positional']>();
+  expectTypeOf(named).toEqualTypeOf<Full['Args']['Named']>();
+});
+
+expectTypeOf(full).toEqualTypeOf<FunctionBasedModifier<Full>>();
+
+// This will be removed at v4 but is currently supported!
+const deprecatedForm = modifier<HTMLAnchorElement, [string], { neat: true }>(
+  (el, pos, named) => {
+    expectTypeOf(el).toEqualTypeOf<HTMLAnchorElement>();
+    expectTypeOf(pos).toEqualTypeOf<[string]>();
+    expectTypeOf(named).toEqualTypeOf<{ neat: true }>();
+  }
+);
+
+expectTypeOf(deprecatedForm).toEqualTypeOf<
+  FunctionBasedModifier<{
+    Element: HTMLAnchorElement;
+    Args: {
+      Named: { neat: true };
+      Positional: [string];
+    };
+  }>
+>();
 
 // This is here simply to "assert" by way of type-checking that it's possible
 // for each of the (type) arguments to be narrowed.
-class NarrowerClass extends Modifier<{
+class DeprecatedClass extends Modifier<{
   named: { onMessage: (desc: string, data: unknown) => void };
   positional: [string];
 }> {
@@ -67,7 +202,7 @@ class NarrowerClass extends Modifier<{
   }
 }
 
-const narrowerClass = new NarrowerClass(
+const deprecatedClass = new DeprecatedClass(
   { iAmAnOwner: 'yep' },
   {
     named: {
@@ -79,13 +214,77 @@ const narrowerClass = new NarrowerClass(
   }
 );
 
-expectTypeOf(narrowerClass).toMatchTypeOf<{
+expectTypeOf(deprecatedClass).toMatchTypeOf<{
   args: {
     named: { onMessage: (desc: string, data: unknown) => void };
     positional: [string];
   };
   element: HTMLIFrameElement;
 }>();
+
+interface ClassBasedSignature {
+  Args: {
+    Named: { onMessage: (desc: string, data: unknown) => void };
+    Positional: [string];
+  };
+  Element: HTMLIFrameElement;
+}
+
+// This is the preferred form going forward, and serves to validate that
+// narrowing works and that inference flows from the signature as expected.
+class ClassBased extends Modifier<ClassBasedSignature> {
+  declare element: HTMLIFrameElement;
+
+  didInstall(): void {
+    this.element.contentWindow?.addEventListener('message', this._handle);
+  }
+
+  willRemove(): void {
+    this.element.contentWindow?.removeEventListener('message', this._handle);
+  }
+
+  _handle(event: MessageEvent): void {
+    this.args.named.onMessage(this.args.positional[0], event.data);
+  }
+}
+
+const classBased = new ClassBased(
+  { iAmAnOwner: 'yep' },
+  {
+    named: {
+      onMessage(desc, data) {
+        console.log(desc, JSON.stringify(data, null, 2));
+      },
+    },
+    positional: ['hello'],
+  }
+);
+
+expectTypeOf(classBased).toMatchTypeOf<{
+  args: {
+    named: { onMessage: (desc: string, data: unknown) => void };
+    positional: [string];
+  };
+  element: HTMLIFrameElement;
+}>();
+
+// @ts-expect-error -- we should reject returning anything other than a function
+// for teardown.
+modifier((el) => {
+  const timer = setTimeout(() => {
+    // whatever, just to use the el
+    console.log(el.innerHTML);
+  }, 1000);
+  return timer;
+});
+
+// @ts-expect-error -- we should reject returning functions which expect
+// arguments for teardown.
+modifier((el) => {
+  el;
+
+  return (interval: number) => clearTimeout(interval);
+});
 
 // --- type utilities --- //
 expectTypeOf<ModifierArgs>().toEqualTypeOf<{

--- a/yarn.lock
+++ b/yarn.lock
@@ -1565,7 +1565,7 @@
   dependencies:
     "@types/ember__object" "*"
 
-"@types/ember__debug@*":
+"@types/ember__debug@*", "@types/ember__debug@~4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/ember__debug/-/ember__debug-4.0.1.tgz#1e4a8a1045484295dddc7bd4356d0b3014b0d509"
   integrity sha512-qrKk6Ujh6oev7TSB0eB7AEmQWKCt5t84k/K3hDvJXUiLU3YueN0kyt7aPoIAkVjC111A9FqDugl9n60+N5yeEw==


### PR DESCRIPTION
## Details

Following the design pioneered in emberjs/rfcs#748, introduce a new `Signature` type and use it in defining the types for both function- and class-based modifiers. This allows end users to write, for example:

```ts
interface PlaySig {
  Args: {
    Named: {
      when: boolean;
    }
  }
  Element: HTMLMediaElement;
}

export default modifier<PlaySig>((el, _, { when: shouldPlay }) => {
  if (shouldPlay) {
    el.play();
  } else {
    el.pause();
  }
});
```

This supports both `Named` and `Positional` args, and works equally well with class-based modifiers. It also provides the `Element` type as `Element` by default, and provides internal type utilities as well as one external-facing type utility to make writing the type of `args` when passed to a modifier `constructor` easy to do in terms of the `Signature` which represents the modifier.

Users do not *need* to type this form: the form using basic inference continues to work as well:

```ts
export default modifier(
  (
    el: HTMLMediaElement,
    _: [],
    { when: shouldPlay }: { when: boolean }
  ) => {
    if (shouldPlay) {
      el.play();
    } else {
      el.pause();
    }
  })
);
```

That is: the support for `Signatures` is strictly *new* capability which was not present before.

The same kind of signature works with class-based modifiers as well, while retaining backward compatibility with the `Args`-based signature and declaration on the subclass `element` field directly. To support that in a way that does not require users to name their args over and over again, introduce an `ArgsFor` type utility which translates from the signature type to the runtime form:

```ts
import Modifier, { ArgsFor } from 'ember-modifier';

interface PlaySig {
  Args: {
    Named: {
      when: boolean;
    };
  };
  Element: HTMLMediaElement;
}

class MyModifier extends Modifier<PlaySig> {
  constructor(owner: unknown, args: ArgsFor<PlaySig>) {
    super(owner, args);
    // ...
  }

  didReceiveArguments() {
    const shouldPlay = this.args.named.when;
    if (shouldPlay) {
      this.element.play();
    } else {
      this.element.pause();
    }
  }
}
```

Additionally, the `modifier` function now returns an opaque `FunctionBasedModifier` type. This mostly exists to provide nice hooks for tooling to hook onto, but it has the added benefit of showing something besides `unknown` in an editor, and that "something" shows the arguments and element specified for the modifier.

## Supporting changes

-   Update the README to match, and fix a *lot* of long-since outdated documentation along the way.

-   Loosen type test constraint to support older TS versions

    The new type signature *is* compatible (as the tests on TS 4.5+ show), but on older versions of TS, it does not check under a type equality check, only under a type matching check. For the purposes of the specific test in question, that's perfectly fine, because the *other* type tests cover inference and resolution correctly.
