### PR TITLE
Introduce new `modify` hook

### DIFF
--- a/addon/-private/class/modifier-manager.ts
+++ b/addon/-private/class/modifier-manager.ts
@@ -1,14 +1,48 @@
 import { capabilities } from '@ember/modifier';
 import { gte } from 'ember-compatibility-helpers';
 import { set } from '@ember/object';
-import { destroy, registerDestructor } from '@ember/destroyable';
+import {
+  destroy,
+  registerDestructor,
+  associateDestroyableChild,
+} from '@ember/destroyable';
 
-import ClassBasedModifier from './modifier';
+import ClassBasedModifier, { _implementsModify } from './modifier';
 import { ArgsFor, ElementFor } from 'ember-modifier/-private/signature';
 import { consumeArgs, Factory, isFactory } from '../compat';
 
 function destroyModifier<S>(modifier: ClassBasedModifier<S>): void {
   modifier.willDestroy();
+}
+
+/**
+ * The state bucket used throughout the life-cycle of the modifier. Basically a
+ * state *machine*, where the framework calls us with the version we hand back
+ * to it at each phase. The two states are the two `extends` versions of this
+ * below.
+ * @internal
+ */
+interface State<S> {
+  instance: ClassBasedModifier<S>;
+  element: ElementFor<S> | null;
+}
+
+/**
+ * The `State` after calling `createModifier`, and therefore the state available
+ * at the start of `InstallModifier`.
+ * @internal
+ */
+interface CreateState<S> extends State<S> {
+  element: null;
+}
+
+/**
+ * The `State` after calling `installModifier`, and therefore the state
+ * available in all subsequent `updateModifier` calls.
+ * @internal
+ */
+interface InstalledState<S> extends State<S> {
+  element: ElementFor<S>;
 }
 
 export default class ClassBasedModifierManager<S> {
@@ -21,43 +55,76 @@ export default class ClassBasedModifierManager<S> {
       | Factory<typeof ClassBasedModifier>
       | typeof ClassBasedModifier,
     args: ArgsFor<S>
-  ): ClassBasedModifier<S> {
+  ): CreateState<S> {
     const Modifier = isFactory(factoryOrClass)
       ? factoryOrClass.class
       : factoryOrClass;
 
     const modifier = new Modifier(this.owner, args);
 
+    const state: CreateState<S> = {
+      instance: modifier,
+      element: null,
+    };
+
+    // Since we have created a state bucket to hand around, we need to make its
+    // destruction trigger the destruction of the modifier. (Ember will
+    // automatically call `destroy` on the state bucket returned from the
+    // `createModifier` hook for precisely this reason.)
+    associateDestroyableChild(state, modifier);
     registerDestructor(modifier, destroyModifier);
 
-    return modifier;
+    return state;
   }
 
   installModifier(
-    instance: ClassBasedModifier<S>,
+    state: State<S>,
     element: ElementFor<S>,
     args: ArgsFor<S>
   ): void {
+    const { instance } = state;
     instance.element = element;
+    state.element = element;
 
-    if (gte('3.22.0')) {
+    // The `consumeArgs()` call backwards compatibility on v3 for the deprecated
+    // legacy lifecycle hooks (`didInstall`, `didReceiveArguments`, and
+    // `didUpdateArguments`), which accidentally had eager consumption semantics
+    // prior to Ember 3.22. The new, recommended `modify` hook has the updated
+    // lazy semantics associated with normal auto-tracking.
+    const implementsModify = _implementsModify(instance);
+    if (gte('3.22.0') && !implementsModify) {
       consumeArgs(args);
     }
 
-    instance.didReceiveArguments();
-    instance.didInstall();
+    if (implementsModify) {
+      instance.modify(element, args.positional, args.named);
+    } else {
+      instance.didReceiveArguments();
+      instance.didInstall();
+    }
   }
 
-  updateModifier(instance: ClassBasedModifier<S>, args: ArgsFor<S>): void {
-    // TODO: this should be an args proxy
-    set(instance, 'args', args);
+  updateModifier(state: InstalledState<S>, args: ArgsFor<S>): void {
+    const { instance } = state;
 
-    if (gte('3.22.0')) {
+    set(instance, 'args', args); // TODO: remove aat 4.0
+
+    // The `consumeArgs()` call backwards compatibility on v3 for the deprecated
+    // legacy lifecycle hooks (`didInstall`, `didReceiveArguments`, and
+    // `didUpdateArguments`), which accidentally had eager consumption semantics
+    // prior to Ember 3.22. The new, recommended `modify` hook has the updated
+    // lazy semantics associated with normal auto-tracking.
+    const implementsModify = _implementsModify(instance);
+    if (gte('3.22.0') && !implementsModify) {
       consumeArgs(args);
     }
 
-    instance.didUpdateArguments();
-    instance.didReceiveArguments();
+    if (implementsModify) {
+      instance.modify(state.element, args.positional, args.named);
+    } else {
+      instance.didUpdateArguments();
+      instance.didReceiveArguments();
+    }
   }
 
   destroyModifier(instance: ClassBasedModifier): void {

--- a/addon/-private/class/modifier-manager.ts
+++ b/addon/-private/class/modifier-manager.ts
@@ -1,11 +1,7 @@
 import { capabilities } from '@ember/modifier';
 import { gte } from 'ember-compatibility-helpers';
 import { set } from '@ember/object';
-import {
-  destroy,
-  registerDestructor,
-  associateDestroyableChild,
-} from '@ember/destroyable';
+import { destroy, registerDestructor } from '@ember/destroyable';
 
 import ClassBasedModifier, { _implementsModify } from './modifier';
 import { ArgsFor, ElementFor } from 'ember-modifier/-private/signature';
@@ -32,7 +28,7 @@ interface State<S> {
  * at the start of `InstallModifier`.
  * @internal
  */
-interface CreateState<S> extends State<S> {
+interface CreatedState<S> extends State<S> {
   element: null;
 }
 
@@ -55,14 +51,14 @@ export default class ClassBasedModifierManager<S> {
       | Factory<typeof ClassBasedModifier>
       | typeof ClassBasedModifier,
     args: ArgsFor<S>
-  ): CreateState<S> {
+  ): CreatedState<S> {
     const Modifier = isFactory(factoryOrClass)
       ? factoryOrClass.class
       : factoryOrClass;
 
     const modifier = new Modifier(this.owner, args);
 
-    const state: CreateState<S> = {
+    const state: CreatedState<S> = {
       instance: modifier,
       element: null,
     };
@@ -73,7 +69,7 @@ export default class ClassBasedModifierManager<S> {
   }
 
   installModifier(
-    state: CreateState<S>,
+    state: CreatedState<S>,
     element: ElementFor<S>,
     args: ArgsFor<S>
   ): void {

--- a/addon/-private/class/modifier-manager.ts
+++ b/addon/-private/class/modifier-manager.ts
@@ -43,6 +43,23 @@ interface InstalledState<S> extends State<S> {
   element: ElementFor<S>;
 }
 
+// Wraps the unsafe (b/c it mutates, rather than creating new state) code that
+// TS does not yet understand.
+function installElement<S>(
+  state: CreatedState<S>,
+  element: ElementFor<S>
+): InstalledState<S> {
+  // SAFETY: this cast represents how we are actually handling the state machine
+  // transition: from this point forward in the lifecycle of the modifier, it
+  // always behaves as `InstalledState<S>`. It is safe because, and *only*
+  // because, we immediately initialize `element`. (We cannot create a new state
+  // from the old one because the modifier manager API expects mutation of a
+  // single state bucket rather than updating it at hook calls.)
+  const installedState = state as State<S> as InstalledState<S>;
+  installedState.element = element;
+  return installedState;
+}
+
 export default class ClassBasedModifierManager<S> {
   capabilities = capabilities(gte('3.22.0') ? '3.22' : '3.13');
 
@@ -69,25 +86,17 @@ export default class ClassBasedModifierManager<S> {
   }
 
   installModifier(
-    state: CreatedState<S>,
+    createdState: CreatedState<S>,
     element: ElementFor<S>,
     args: ArgsFor<S>
   ): void {
-    // SAFETY: this cast represents how we are actually handling the state
-    // machine transition: from this point forward in the lifecycle of the
-    // modifier, it always behaves as `InstalledState<S>`. It is safe because,
-    // and *only* because, we immediately initialize `element`. (We cannot
-    // create a new state from the old one because the modifier manager API
-    // expects mutation of a single state bucket rather than updating it at
-    // hook calls.)
-    const installedState = state as State<S> as InstalledState<S>;
-    installedState.element = element;
+    const state = installElement(createdState, element);
 
     // TODO: this can be deleted entirely at v4.
-    const { instance } = installedState;
+    const { instance } = state;
     instance.element = element;
 
-    if (installedState.implementsModify) {
+    if (state.implementsModify) {
       instance.modify(element, args.positional, args.named);
     } else {
       // The `consumeArgs()` call provides backwards compatibility on v3 for the

--- a/addon/-private/class/modifier.ts
+++ b/addon/-private/class/modifier.ts
@@ -109,17 +109,16 @@ export default class ClassBasedModifier<S = DefaultSignature> {
    * class IntersectionObserver extends Modifier {
    *   observer;
    *
+   *   constructor(owner, args) {
+   *     super(owner, args);
+   *     registerDestructor(this, disconnect);
+   *   }
+   *
    *   modify(element, callback, options) {
-   *     // Gets rid of any existing connection, since we're getting called with
-   *     // a new callback or new options, and drops any existing destructor
-   *     // registrations so we avoid having extra destructors lying around.
    *     disconnect(this);
-   *     unregisterDestructor(this, disconnect);
    *
    *     this.observer = new IntersectionObserver(callback, options);
    *     this.observer.observe(element);
-   *
-   *     registerDestructor(this, disconnect);
    *   }
    * }
    * ```

--- a/addon/-private/class/modifier.ts
+++ b/addon/-private/class/modifier.ts
@@ -87,7 +87,7 @@ export default class ClassBasedModifier<S = DefaultSignature> {
     deprecateForDestroyables('isDestroyed', this);
 
     assert(
-      'ember-modifier: You cannot implement both `run` and any of the deprecated legacy lifecycle hooks (`didInstall`, `didReceiveArguments`, and `didUpdateArguments`)',
+      'ember-modifier: You cannot implement both `modify` and any of the deprecated legacy lifecycle hooks (`didInstall`, `didReceiveArguments`, and `didUpdateArguments`)',
       !(_implementsModify(this) && _implementsLegacyHooks(this))
     );
   }

--- a/addon/-private/class/modifier.ts
+++ b/addon/-private/class/modifier.ts
@@ -2,8 +2,14 @@ import { setOwner } from '@ember/application';
 import { setModifierManager } from '@ember/modifier';
 import Manager from './modifier-manager';
 import { isDestroying, isDestroyed } from '@ember/destroyable';
-import { ElementFor, ArgsFor, DefaultSignature } from '../signature';
-import { deprecate } from '@ember/debug';
+import {
+  ElementFor,
+  ArgsFor,
+  DefaultSignature,
+  PositionalArgs,
+  NamedArgs,
+} from '../signature';
+import { assert, deprecate } from '@ember/debug';
 
 function deprecateForDestroyables<S>(
   name: 'willDestroy' | 'isDestroying' | 'isDestroyed',
@@ -23,6 +29,21 @@ function deprecateForDestroyables<S>(
     }
   );
 }
+
+/** @internal */
+export const _implementsModify = <S>(
+  instance: ClassBasedModifier<S>
+): boolean => instance.modify !== ClassBasedModifier.prototype.modify;
+
+/** @internal */
+export const _implementsLegacyHooks = <S>(
+  instance: ClassBasedModifier<S>
+): boolean =>
+  instance.didInstall !== ClassBasedModifier.prototype.didInstall ||
+  instance.didUpdateArguments !==
+    ClassBasedModifier.prototype.didUpdateArguments ||
+  instance.didReceiveArguments !==
+    ClassBasedModifier.prototype.didReceiveArguments;
 
 /**
  * A base class for modifiers which need more capabilities than function-based
@@ -64,6 +85,55 @@ export default class ClassBasedModifier<S = DefaultSignature> {
     deprecateForDestroyables('willDestroy', this);
     deprecateForDestroyables('isDestroying', this);
     deprecateForDestroyables('isDestroyed', this);
+
+    assert(
+      'ember-modifier: You cannot implement both `run` and any of the deprecated legacy lifecycle hooks (`didInstall`, `didReceiveArguments`, and `didUpdateArguments`)',
+      !(_implementsModify(this) && _implementsLegacyHooks(this))
+    );
+  }
+
+  /**
+   * Called when the modifier is installed and any time any tracked state used
+   * in the modifier changes.
+   *
+   * If you need to do first-time-only setup, create a class field representing
+   * the initialization state and check it when running the hook. That is also
+   * where and when you should use `registerDestructor` for any teardown you
+   * need to do. For example:
+   *
+   * ```js
+   * function disconnect(instance) {
+   *  instnace.observer?.disconnect();
+   * }
+   *
+   * class IntersectionObserver extends Modifier {
+   *   observer;
+   *
+   *   modify(element, callback, options) {
+   *     // Gets rid of any existing connection, since we're getting called with
+   *     // a new callback or new options.
+   *     disconnect(this);
+   *
+   *     this.observer = new IntersectionObserver(callback, options);
+   *     this.observer.observe(element);
+   *
+   *     registerDestructor(this, disconnect);
+   *   }
+   * }
+   * ```
+   *
+   * @param element The element to which the modifier is applied.
+   * @param positional The positional arguments to the modifier.
+   * @param named The named arguments to the modifier.
+   */
+  modify(
+    /* eslint-disable @typescript-eslint/no-unused-vars */
+    element: ElementFor<S>,
+    positional: PositionalArgs<S>,
+    named: NamedArgs<S>
+    /* eslint-enable @typescript-eslint/no-unused-vars */
+  ): void {
+    /* no op, for subclassing */
   }
 
   /**

--- a/addon/-private/class/modifier.ts
+++ b/addon/-private/class/modifier.ts
@@ -103,7 +103,7 @@ export default class ClassBasedModifier<S = DefaultSignature> {
    *
    * ```js
    * function disconnect(instance) {
-   *  instnace.observer?.disconnect();
+   *  instance.observer?.disconnect();
    * }
    *
    * class IntersectionObserver extends Modifier {
@@ -111,8 +111,10 @@ export default class ClassBasedModifier<S = DefaultSignature> {
    *
    *   modify(element, callback, options) {
    *     // Gets rid of any existing connection, since we're getting called with
-   *     // a new callback or new options.
+   *     // a new callback or new options, and drops any existing destructor
+   *     // registrations so we avoid having extra destructors lying around.
    *     disconnect(this);
+   *     unregisterDestructor(this, disconnect);
    *
    *     this.observer = new IntersectionObserver(callback, options);
    *     this.observer.observe(element);

--- a/addon/-private/compat.ts
+++ b/addon/-private/compat.ts
@@ -31,8 +31,15 @@ let consumeArgs: <S>(args: ArgsFor<S>) => void = noop;
 
 if (gte('3.22.0')) {
   consumeArgs = function ({ positional, named }) {
-    for (let i = 0; i < positional.length; i++) {
-      positional[i];
+    // SAFETY: TS before 4.6 does not correctly/fully resolve the type in a way
+    // that allows the type checker to see that `positional` must *always* be
+    // something which `extends unknown[]` here, because the underlying
+    // machinery is fairly complicated and relies on a fair bit of type
+    // recursion. It will stop mattering when we cut v4.0, because we won't be
+    // doing this anyway.
+    const pos = positional as unknown[];
+    for (let i = 0; i < pos.length; i++) {
+      pos[i];
     }
 
     Object.values(named);

--- a/addon/-private/compat.ts
+++ b/addon/-private/compat.ts
@@ -27,10 +27,10 @@ const noop = (): void => {};
  * avoid introducing a breaking change until a suitable transition path is made
  * available.
  */
-let consumeArgs: (args: ArgsFor<any>) => void = noop;
+let consumeArgs: <S>(args: ArgsFor<S>) => void = noop;
 
 if (gte('3.22.0')) {
-  consumeArgs = function ({ positional, named }: ArgsFor<any>) {
+  consumeArgs = function ({ positional, named }) {
     for (let i = 0; i < positional.length; i++) {
       positional[i];
     }

--- a/addon/-private/signature.ts
+++ b/addon/-private/signature.ts
@@ -22,12 +22,14 @@ type DefaultPositional = unknown[];
 /** @private */
 export type PositionalArgs<S> = 'Args' extends keyof S
   ? 'Positional' extends keyof S['Args']
-    ? S['Args']['Positional'] extends unknown[]
+    ? S['Args']['Positional'] extends DefaultPositional
       ? S['Args']['Positional']
       : DefaultPositional
     : DefaultPositional
   : 'positional' extends keyof S
-  ? S['positional']
+  ? S['positional'] extends DefaultPositional
+    ? S['positional']
+    : DefaultPositional
   : DefaultPositional;
 
 type DefaultNamed = Record<string, unknown>;
@@ -35,12 +37,14 @@ type DefaultNamed = Record<string, unknown>;
 /** @private */
 export type NamedArgs<S> = 'Args' extends keyof S
   ? 'Named' extends keyof S['Args']
-    ? S['Args']['Named'] extends Record<string, unknown>
+    ? S['Args']['Named'] extends DefaultNamed
       ? S['Args']['Named']
       : DefaultNamed
     : DefaultNamed
   : 'named' extends keyof S
-  ? S['named']
+  ? S['named'] extends DefaultNamed
+    ? S['named']
+    : DefaultNamed
   : DefaultNamed;
 
 /** @private */
@@ -48,7 +52,6 @@ export interface DefaultSignature {
   Element: Element;
 }
 
-/** @private */
 export interface ArgsFor<S> {
   named: NamedArgs<S>;
   positional: PositionalArgs<S>;

--- a/addon/-private/signature.ts
+++ b/addon/-private/signature.ts
@@ -19,33 +19,23 @@ export type ElementFor<S> = 'Element' extends keyof S
 
 type DefaultPositional = unknown[];
 
+type Args<S, K, Fallback> = K extends keyof S
+  ? S[K] extends Fallback
+    ? S[K]
+    : Fallback
+  : Fallback;
+
 /** @private */
 export type PositionalArgs<S> = 'Args' extends keyof S
-  ? 'Positional' extends keyof S['Args']
-    ? S['Args']['Positional'] extends DefaultPositional
-      ? S['Args']['Positional']
-      : DefaultPositional
-    : DefaultPositional
-  : 'positional' extends keyof S
-  ? S['positional'] extends DefaultPositional
-    ? S['positional']
-    : DefaultPositional
-  : DefaultPositional;
+  ? Args<S['Args'], 'Positional', DefaultPositional>
+  : Args<S, 'positional', DefaultPositional>;
 
 type DefaultNamed = Record<string, unknown>;
 
 /** @private */
 export type NamedArgs<S> = 'Args' extends keyof S
-  ? 'Named' extends keyof S['Args']
-    ? S['Args']['Named'] extends DefaultNamed
-      ? S['Args']['Named']
-      : DefaultNamed
-    : DefaultNamed
-  : 'named' extends keyof S
-  ? S['named'] extends DefaultNamed
-    ? S['named']
-    : DefaultNamed
-  : DefaultNamed;
+  ? Args<S['Args'], 'Named', DefaultNamed>
+  : Args<S, 'named', DefaultNamed>;
 
 /** @private */
 export interface DefaultSignature {

--- a/tests/integration/modifiers/class-modifier-test.ts
+++ b/tests/integration/modifiers/class-modifier-test.ts
@@ -4,8 +4,14 @@ import { render, settled } from '@ember/test-helpers';
 import type { TestContext as BaseContext } from '@ember/test-helpers';
 import Service, { inject as service } from '@ember/service';
 import { hbs } from 'ember-cli-htmlbars';
-import Modifier, { ModifierArgs } from 'ember-modifier';
+import Modifier, { ArgsFor } from 'ember-modifier';
 import ClassBasedModifier from 'ember-modifier';
+import {
+  DefaultSignature,
+  NamedArgs,
+  PositionalArgs,
+} from 'ember-modifier/-private/signature';
+import { tracked } from '@glimmer/tracking';
 
 // `any` required for the inference to work correctly here
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -33,7 +39,7 @@ interface Context extends BaseContext {
   hook(assertions: (instance: ClassBasedModifier) => void): void;
 }
 
-function testHook({
+function testLifecycleHook({
   name,
   insert,
   update,
@@ -400,8 +406,8 @@ function testHooksOrdering(factory: Factory): void {
   });
 }
 
-function testHooks(factory: Factory): void {
-  testHook({
+function testLegacyHooks(factory: Factory): void {
+  testLifecycleHook({
     name: 'constructor',
     insert: true,
     update: false,
@@ -410,7 +416,7 @@ function testHooks(factory: Factory): void {
     factory,
   });
 
-  testHook({
+  testLifecycleHook({
     name: 'didReceiveArguments',
     insert: true,
     update: true,
@@ -419,7 +425,7 @@ function testHooks(factory: Factory): void {
     factory,
   });
 
-  testHook({
+  testLifecycleHook({
     name: 'didUpdateArguments',
     insert: false,
     update: true,
@@ -428,7 +434,7 @@ function testHooks(factory: Factory): void {
     factory,
   });
 
-  testHook({
+  testLifecycleHook({
     name: 'didInstall',
     insert: true,
     update: false,
@@ -437,7 +443,7 @@ function testHooks(factory: Factory): void {
     factory,
   });
 
-  testHook({
+  testLifecycleHook({
     name: 'willDestroy',
     insert: false,
     update: false,
@@ -454,10 +460,11 @@ module(
   function (hooks) {
     setupRenderingTest(hooks);
 
-    testHooks(
+    // NOTE: this can be removed at 4.0.
+    testLegacyHooks(
       (callback) =>
         class NativeModifier extends Modifier {
-          constructor(owner: unknown, args: ModifierArgs) {
+          constructor(owner: unknown, args: ArgsFor<DefaultSignature>) {
             super(owner, args);
             callback('constructor', this);
           }
@@ -479,6 +486,197 @@ module(
           }
         }
     );
+
+    test('the constructor', async function (assert) {
+      let callCount = 0;
+      class UsingConstructor extends Modifier {
+        constructor(owner: unknown, args: ArgsFor<DefaultSignature>) {
+          super(owner, args);
+          assert.equal(callCount, 0, 'has initially never been called');
+          callCount += 1;
+
+          assert.equal(arguments.length, 2, 'receives exactly two arguments');
+          assert.true('named' in args, 'the `args` has a `named` field');
+          assert.equal(typeof args.named, 'object', 'which is an object');
+          assert.true(
+            'positional' in args,
+            'the `args` has a `positional` field'
+          );
+          assert.true(Array.isArray(args.positional), 'which is an array');
+        }
+      }
+
+      this.owner.register('modifier:using-constructor', UsingConstructor);
+
+      class State {
+        @tracked pos = 'pos';
+        @tracked named = 'named';
+      }
+      const state = new State();
+      this.set('state', state);
+
+      await render(hbs`
+        <h1 id="expected" {{using-constructor this.state.pos named=this.state.named}}>Hello</h1>
+      `);
+
+      assert.step('construction');
+
+      state.pos = 'new pos';
+      await settled();
+      assert.step('first rerender');
+
+      state.named = 'new named';
+      await settled();
+      assert.step('second rerender');
+
+      assert.equal(callCount, 1, 'only gets called once');
+      assert.verifySteps(['construction', 'first rerender', 'second rerender']);
+    });
+
+    test('the `modify` hook', async function (assert) {
+      interface ModifySig {
+        Element: HTMLParagraphElement;
+        Args: {
+          Named: {
+            name: string;
+            age: number;
+          };
+          Positional: [greet: string, farewell: string];
+        };
+      }
+
+      class State {
+        @tracked greet = 'hello';
+        @tracked farewell = 'goodbye';
+        @tracked name = 'Chris';
+        @tracked age = 34;
+      }
+
+      const state = new State();
+      this.set('state', state); // RFC 785
+
+      let modifyCallCount = 0;
+
+      class UsingModify extends Modifier<ModifySig> {
+        constructor(owner: unknown, args: ArgsFor<ModifySig>) {
+          super(owner, args);
+          assert.equal(arguments.length, 2, '');
+        }
+
+        modify(
+          element: HTMLParagraphElement,
+          positional: PositionalArgs<ModifySig>,
+          named: NamedArgs<ModifySig>
+        ): void {
+          modifyCallCount += 1;
+          assert.true(
+            element instanceof HTMLParagraphElement,
+            'receives the element correctly'
+          );
+          assert.equal(positional.length, 2, 'receives all positional args');
+          assert.equal(
+            positional[0],
+            state.greet,
+            'receives 1st positional arg'
+          );
+          assert.equal(
+            positional[1],
+            state.farewell,
+            'receives 2nd positional arg'
+          );
+
+          // Intentionally do not use `named.age`, so that we can test that
+          // modify is appropriately "lazy" about what it consumes: triggering
+          // a `set` operation on it will not
+          assert.equal(typeof named, 'object', 'receives a named args object');
+          assert.equal(named.name, state.name, 'receives correct named args');
+        }
+      }
+
+      this.owner.register('modifier:using-modify', UsingModify);
+
+      await render(hbs`
+        <p {{using-modify this.state.greet this.state.farewell name=this.state.name}}></p>
+      `);
+
+      assert.step('initial render');
+
+      state.greet = 'ahoy';
+      await settled();
+      assert.step('second render');
+
+      state.name = 'Krycho';
+      await settled();
+      assert.step('third render');
+
+      // This should *not* trigger `modify`, so the call count will remain 3.
+      state.age = 35;
+      await settled();
+      assert.step('fourth render');
+
+      assert.equal(
+        modifyCallCount,
+        3,
+        'is called once each for installation and each update to args it actually uses'
+      );
+      assert.verifySteps([
+        'initial render',
+        'second render',
+        'third render',
+        'fourth render',
+      ]);
+    });
+
+    // TODO: remove at 4.0
+    module('using modify with legacy hooks', function () {
+      test('didInstall', function (assert) {
+        class WithDI extends Modifier {
+          didInstall(): void {
+            /* no op */
+          }
+          modify(): void {
+            /* no op */
+          }
+        }
+
+        assert.throws(
+          () => new WithDI({}, { named: {}, positional: [] }),
+          'throws'
+        );
+      });
+
+      test('didReceiveArguments', function (assert) {
+        class WithDRA extends Modifier {
+          didReceiveArguments(): void {
+            /* no op */
+          }
+          modify(): void {
+            /* no op */
+          }
+        }
+
+        assert.throws(
+          () => new WithDRA({}, { named: {}, positional: [] }),
+          'throws'
+        );
+      });
+
+      test('didUpdateArguments', function (assert) {
+        class WithDUA extends Modifier {
+          didUpdateArguments(): void {
+            /* no op */
+          }
+          modify(): void {
+            /* no op */
+          }
+        }
+
+        assert.throws(
+          () => new WithDUA({}, { named: {}, positional: [] }),
+          'throws'
+        );
+      });
+    });
 
     module('service injection', function () {
       test('can participate in ember dependency injection', async function (this: Context, assert) {
@@ -504,7 +702,7 @@ module(
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           @service('bar' as any) baz!: Bar;
 
-          constructor(owner: unknown, args: ModifierArgs) {
+          constructor(owner: unknown, args: ArgsFor<DefaultSignature>) {
             super(owner, args);
 
             called = true;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "alwaysStrict": true,
     "noFallthroughCasesInSwitch": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": true,
+    "noUnusedParameters": false,
     "noImplicitReturns": true,
     "noEmitOnError": false,
     "noEmit": true,


### PR DESCRIPTION
This hook is the future of the class-based modifier API; it replaces *all* the non-destruction lifecycle hooks. The new API closely mirrors both the existing function-based modifier design and the design of class-based helpers in Ember:

```ts
import Modifier from 'ember-modifier';

export default class MyModifier extends Modifier {
  modify(element, positional, named) {
    // ...
  }
}
```

This API shift results in several significant improvements compared to the previous API:

1.  The signature of `Modifier.modify` matches the signature of a function-based signature. Both receive the element and both positional and named arguments directly, and in the same positions. This means that transitioning from a function- to a class-based helper is as simple as using the callback passed to `modifier` as the `modify` method on the class. Users no longer need

2.  It now matches the API of a class-based `Helper`, which has only the single `compute` method. This is important for rationalizing the mental model for using them: Modifiers and helpers are *very* similar, with the key difference being that helpers are intended to be pure functions which produce values, while modifiers are intended to be impure functions which mutate (modify!) a piece of DOM and do *not* return values.

3.  This allows us to introduce the desired semantics for modifiers *without a breaking change*. Unlike the existing lifecycle hooks, `modify` does *not* eagerly consume its arguments. Instead, matching the rest of the framework, it only entangles with the tracked values it *actually uses*. This means that users should take care when migrating their existing modifiers to use the new hook.

    To maintain exact backwards compatibility, modifier authors would need to explicitly use all of the arguments passed to their modifiers. Instead, modifier authors should generally cut a new major version which has the updated, lazy semantics.

It is a hard error to use `modify` along with any of the existing (non-destruction) lifecycle hooks. This allows us to guarantee that `modify` maintains the standard auto-tracking semantics as described above.

With `modify` available, deprecate the existing lifecycle hooks; users will need to begin migrating to the new design. By introducing `modify` this way, however, users can migrate their existing modifiers piecemeal.