### PR TITLE
Add ':no_entry_sign: Deprecations' to lerna config

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,16 @@
         "launchEditor": true
       }
     },
+    "changelog": {
+      "labels": {
+        "breaking": ":boom: Breaking Change",
+        "enhancement": ":rocket: Enhancement",
+        "bug": ":bug: Bug Fix",
+        "documentation": ":memo: Documentation",
+        "internal": ":house: Internal",
+        "deprecation": ":no_entry_sign: Deprecations"
+      }
+    },
     "git": {
       "tagName": "v${version}"
     },


### PR DESCRIPTION
This lets us flag up deprecations in their own heading:

> ## :no_entry_sign: Deprecations
> - Don't use things you're not allowed to anymore