### PR TITLE
Introduce `eager` option to function-based modifiers

### DIFF
--- a/addon/-private/functional/modifier.ts
+++ b/addon/-private/functional/modifier.ts
@@ -190,7 +190,7 @@ export default function modifier(
     positional: unknown[],
     named: object
   ) => void | Teardown,
-  options?: { eager: boolean }
+  options: { eager: boolean } = { eager: true }
 ): FunctionBasedModifier<{
   Element: Element;
   Args: {
@@ -202,9 +202,8 @@ export default function modifier(
   // type of `setModifierManager` today is `void`; we pretend it actually
   // returns an opaque `Modifier` type so that we can provide a result from this
   // type which is useful to TS-aware tooling (e.g. Glint).
-  const isEager = !options || options?.eager;
   return setModifierManager(
-    () => (isEager ? EAGER_MANAGER : LAZY_MANAGER),
+    () => (options.eager ? EAGER_MANAGER : LAZY_MANAGER),
     fn
   ) as unknown as FunctionBasedModifier<{
     Element: Element;

--- a/addon/-private/functional/modifier.ts
+++ b/addon/-private/functional/modifier.ts
@@ -32,7 +32,7 @@ export interface FunctionBasedModifier<S = DefaultSignature>
  * cleanup or teardown -- for example, removing an event listener from an
  * element besides the one passed into the modifier.
  */
-type Teardown = () => unknown;
+export type Teardown = () => unknown;
 
 /**
  * An API for writing simple modifiers.
@@ -54,9 +54,67 @@ type Teardown = () => unknown;
 export default function modifier<
   E extends Element,
   P extends unknown[],
-  N extends Record<string, unknown>
+  N extends object
 >(
   fn: (element: E, positional: P, named: N) => void | Teardown
+): FunctionBasedModifier<{
+  Args: { Named: N; Positional: P };
+  Element: E;
+}>;
+
+/**
+ * An API for writing simple modifiers.
+ *
+ * This function runs the first time when the element the modifier was applied
+ * to is inserted into the DOM, and it *autotracks* while running. Any values
+ * that it accesses will be tracked, including the arguments it receives, and if
+ * any of them changes, the function will run again.
+ *
+ * The modifier can also optionally return a *destructor*. The destructor
+ * function will be run just before the next update, and when the element is
+ * being removed entirely. It should generally clean up the changes that the
+ * modifier made in the first place.
+ *
+ * @param fn The function which defines the modifier.
+ */
+// This overload allows users to write types directly on the callback passed to
+// the `modifier` function and infer the resulting type correctly.
+export default function modifier<
+  E extends Element,
+  P extends unknown[],
+  N extends object
+>(
+  fn: (element: E, positional: P, named: N) => void | Teardown,
+  options: { eager: true }
+): FunctionBasedModifier<{
+  Args: { Named: N; Positional: P };
+  Element: E;
+}>;
+
+/**
+ * An API for writing simple modifiers.
+ *
+ * This function runs the first time when the element the modifier was applied
+ * to is inserted into the DOM, and it *autotracks* while running. Any values
+ * that it accesses will be tracked, including the arguments it receives, and if
+ * any of them changes, the function will run again.
+ *
+ * The modifier can also optionally return a *destructor*. The destructor
+ * function will be run just before the next update, and when the element is
+ * being removed entirely. It should generally clean up the changes that the
+ * modifier made in the first place.
+ *
+ * @param fn The function which defines the modifier.
+ */
+// This overload allows users to write types directly on the callback passed to
+// the `modifier` function and infer the resulting type correctly.
+export default function modifier<
+  E extends Element,
+  P extends unknown[],
+  N extends object
+>(
+  fn: (element: E, positional: P, named: N) => void | Teardown,
+  options: { eager: false }
 ): FunctionBasedModifier<{
   Args: { Named: N; Positional: P };
   Element: E;
@@ -72,7 +130,8 @@ export default function modifier<S>(
     element: ElementFor<S>,
     positional: PositionalArgs<S>,
     named: NamedArgs<S>
-  ) => void | Teardown
+  ) => void | Teardown,
+  options: { eager: false }
 ): FunctionBasedModifier<{
   Element: ElementFor<S>;
   Args: {
@@ -89,12 +148,13 @@ export default function modifier(
   fn: (
     element: Element,
     positional: unknown[],
-    named: Record<string, undefined>
-  ) => void | Teardown
+    named: object
+  ) => void | Teardown,
+  options?: { eager: boolean }
 ): FunctionBasedModifier<{
   Element: Element;
   Args: {
-    Named: Record<string, unknown>;
+    Named: object;
     Positional: unknown[];
   };
 }> {
@@ -103,12 +163,12 @@ export default function modifier(
   // returns an opaque `Modifier` type so that we can provide a result from this
   // type which is useful to TS-aware tooling (e.g. Glint).
   return setModifierManager(
-    () => FunctionalModifierManager,
+    () => new FunctionalModifierManager(options),
     fn
   ) as unknown as FunctionBasedModifier<{
     Element: Element;
     Args: {
-      Named: Record<string, unknown>;
+      Named: object;
       Positional: unknown[];
     };
   }>;

--- a/addon/-private/functional/modifier.ts
+++ b/addon/-private/functional/modifier.ts
@@ -7,6 +7,12 @@ import {
 } from '../signature';
 import FunctionalModifierManager from './modifier-manager';
 
+// Provide a singleton manager for each of the options. (If we extend this to
+// many more options in the future, we can revisit, but for now this means we
+// only ever allocate two managers.)
+const EAGER_MANAGER = new FunctionalModifierManager({ eager: true });
+const LAZY_MANAGER = new FunctionalModifierManager({ eager: false });
+
 // Type-only utilities used for representing the type of a Modifier in a way
 // that (a) has no runtime overhead and (b) makes no public API commitment: by
 // extending it with an interface representing the modifier, its internals
@@ -162,8 +168,9 @@ export default function modifier(
   // type of `setModifierManager` today is `void`; we pretend it actually
   // returns an opaque `Modifier` type so that we can provide a result from this
   // type which is useful to TS-aware tooling (e.g. Glint).
+  const isEager = !options || options?.eager;
   return setModifierManager(
-    () => new FunctionalModifierManager(options),
+    () => (isEager ? EAGER_MANAGER : LAZY_MANAGER),
     fn
   ) as unknown as FunctionBasedModifier<{
     Element: Element;

--- a/addon/-private/functional/modifier.ts
+++ b/addon/-private/functional/modifier.ts
@@ -45,8 +45,12 @@ export type Teardown = () => unknown;
  *
  * This function runs the first time when the element the modifier was applied
  * to is inserted into the DOM, and it *autotracks* while running. Any values
- * that it accesses will be tracked, including the arguments it receives, and if
- * any of them changes, the function will run again.
+ * that it accesses will be tracked, and if any of them changes, the function
+ * will run again.
+ *
+ * **Note:** this will rerun if any of its arguments change, *whether or not you
+ * access them*. This is legacy behavior and you should switch to using the
+ * `{ eager: false }` variant, which has normal auto-tracking semantics.
  *
  * The modifier can also optionally return a *destructor*. The destructor
  * function will be run just before the next update, and when the element is
@@ -73,8 +77,12 @@ export default function modifier<
  *
  * This function runs the first time when the element the modifier was applied
  * to is inserted into the DOM, and it *autotracks* while running. Any values
- * that it accesses will be tracked, including the arguments it receives, and if
- * any of them changes, the function will run again.
+ * that it accesses will be tracked, and if any of them changes, the function
+ * will run again.
+ *
+ * **Note:** this will rerun if any of its arguments change, *whether or not you
+ * access them*. This is legacy behavior and you should switch to using the
+ * `{ eager: false }` variant, which has normal auto-tracking semantics.
  *
  * The modifier can also optionally return a *destructor*. The destructor
  * function will be run just before the next update, and when the element is
@@ -82,6 +90,7 @@ export default function modifier<
  * modifier made in the first place.
  *
  * @param fn The function which defines the modifier.
+ * @param options Configuration for the modifier.
  */
 // This overload allows users to write types directly on the callback passed to
 // the `modifier` function and infer the resulting type correctly.
@@ -102,8 +111,12 @@ export default function modifier<
  *
  * This function runs the first time when the element the modifier was applied
  * to is inserted into the DOM, and it *autotracks* while running. Any values
- * that it accesses will be tracked, including the arguments it receives, and if
- * any of them changes, the function will run again.
+ * that it accesses will be tracked, including any of its arguments that it
+ * accesses, and if any of them changes, the function will run again.
+ *
+ * **Note:** this will *not* automatically rerun because an argument changes. It
+ * will only rerun if it is *using* that argument (the same as with auto-tracked
+ * state in general).
  *
  * The modifier can also optionally return a *destructor*. The destructor
  * function will be run just before the next update, and when the element is
@@ -111,6 +124,7 @@ export default function modifier<
  * modifier made in the first place.
  *
  * @param fn The function which defines the modifier.
+ * @param options Configuration for the modifier.
  */
 // This overload allows users to write types directly on the callback passed to
 // the `modifier` function and infer the resulting type correctly.
@@ -126,6 +140,26 @@ export default function modifier<
   Element: E;
 }>;
 
+/**
+ * An API for writing simple modifiers.
+ *
+ * This function runs the first time when the element the modifier was applied
+ * to is inserted into the DOM, and it *autotracks* while running. Any values
+ * that it accesses will be tracked, including any of its arguments that it
+ * accesses, and if any of them changes, the function will run again.
+ *
+ * **Note:** this will *not* automatically rerun because an argument changes. It
+ * will only rerun if it is *using* that argument (the same as with auto-tracked
+ * state in general).
+ *
+ * The modifier can also optionally return a *destructor*. The destructor
+ * function will be run just before the next update, and when the element is
+ * being removed entirely. It should generally clean up the changes that the
+ * modifier made in the first place.
+ *
+ * @param fn The function which defines the modifier.
+ * @param options Configuration for the modifier.
+ */
 // This overload allows users to provide a `Signature` type explicitly at the
 // modifier definition site, e.g. `modifier<Sig>((el, pos, named) => {...})`.
 // **Note:** this overload must appear second, since TS' inference engine will

--- a/addon/-private/signature.ts
+++ b/addon/-private/signature.ts
@@ -30,7 +30,7 @@ export type PositionalArgs<S> = 'Args' extends keyof S
   ? Args<S['Args'], 'Positional', DefaultPositional>
   : Args<S, 'positional', DefaultPositional>;
 
-type DefaultNamed = Record<string, unknown>;
+type DefaultNamed = object;
 
 /** @private */
 export type NamedArgs<S> = 'Args' extends keyof S

--- a/addon/-private/signature.ts
+++ b/addon/-private/signature.ts
@@ -5,7 +5,7 @@ export interface ModifierArgs {
   /** Positional arguments to a modifier, `{{foo @bar this.baz}}` */
   positional: unknown[];
   /** Named arguments to a modifier, `{{foo bar=this.baz}}` */
-  named: Record<string, unknown>;
+  named: object;
 }
 
 // --- Type utilities for use with Signature types --- //

--- a/tests/integration/modifiers/functional-modifier-test.ts
+++ b/tests/integration/modifiers/functional-modifier-test.ts
@@ -4,6 +4,7 @@ import { render, settled } from '@ember/test-helpers';
 import type { TestContext as BaseContext } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { modifier } from 'ember-modifier';
+import { tracked } from '@glimmer/tracking';
 
 type ModifierReturn = ReturnType<typeof modifier>;
 
@@ -12,6 +13,7 @@ interface TestContext extends BaseContext {
   shouldRender?: boolean;
   isRendered?: boolean;
   value?: number;
+  state?: unknown;
 }
 
 module('Integration | Modifiers | functional modifier', function (hooks) {
@@ -153,6 +155,126 @@ module('Integration | Modifiers | functional modifier', function (hooks) {
       assert.equal(teardownCalls.length, 2);
       assert.ok(teardownCalls.includes('A'));
       assert.ok(teardownCalls.includes('B'));
+    });
+  });
+
+  module('auto-tracking behavior', function () {
+    class State {
+      @tracked a = 123;
+      @tracked b = 456;
+    }
+
+    module('legacy', function () {
+      test('by defaulting with no options object', async function (this: TestContext, assert) {
+        let callCount = 0;
+
+        const state = (this.state = new State());
+
+        // For legacy behavior, we do not need to consume args *at all*. We just
+        // need to invoke the modifier with them and then change them.
+        this.owner.register(
+          'modifier:legacy',
+          modifier(() => {
+            callCount++;
+          })
+        );
+
+        await render(hbs`
+          <div {{legacy this.state.a this.state.b}}></div>
+        `);
+        assert.step('first render');
+        assert.equal(callCount, 1, 'installation runs the modifier');
+
+        state.a = 234;
+        await settled();
+        assert.step('second render');
+        assert.equal(callCount, 2, 'updating unused arg a runs the modifier');
+
+        state.b = 987;
+        await settled();
+        assert.step('third render');
+        assert.equal(callCount, 3, 'updating unused arg b runs the modifier');
+
+        assert.verifySteps(['first render', 'second render', 'third render']);
+      });
+
+      test('by passing `{ eager: true }` explicitly', async function (this: TestContext, assert) {
+        let callCount = 0;
+
+        const state = (this.state = new State());
+
+        // For legacy behavior, we do not need to consume args *at all*. We just
+        // need to invoke the modifier with them and then change them.
+        this.owner.register(
+          'modifier:explicitly-eager',
+          modifier(
+            () => {
+              callCount++;
+            },
+            { eager: true }
+          )
+        );
+
+        await render(hbs`
+          <div {{explicitly-eager this.state.a this.state.b}}></div>
+        `);
+        assert.step('first render');
+        assert.equal(callCount, 1, 'installation runs the modifier');
+
+        state.a = 234;
+        await settled();
+        assert.step('second render');
+        assert.equal(callCount, 2, 'updating unused arg a runs the modifier');
+
+        state.b = 987;
+        await settled();
+        assert.step('third render');
+        assert.equal(callCount, 3, 'updating unused arg b runs the modifier');
+
+        assert.verifySteps(['first render', 'second render', 'third render']);
+      });
+    });
+
+    test('with `{ eager: false }`', async function (this: TestContext, assert) {
+      let callCount = 0;
+
+      const state = (this.state = new State());
+
+      // For the modern behavior, we *do* need to consume the args to be updated
+      // when they change. Here, we consume `state.a` but *not* `state.b`, and
+      // test setting both `a` and `b` below.
+      this.owner.register(
+        'modifier:explicitly-lazy',
+        modifier(
+          (_el: Element, _pos: [], state: State) => {
+            state.a;
+            callCount++;
+          },
+          { eager: false }
+        )
+      );
+
+      await render(hbs`
+        <div {{explicitly-lazy a=this.state.a b=this.state.b}}></div>
+      `);
+      assert.step('first render');
+      assert.equal(callCount, 1, 'installation runs the modifier');
+
+      state.a = 234;
+      await settled();
+      assert.step('second render');
+      assert.equal(callCount, 2, 'updating used arg a runs the modifier');
+
+      state.b = 987;
+      await settled();
+      assert.step('third render');
+      assert.equal(
+        callCount,
+        2,
+        'updating unused arg b does not run the modifier'
+      );
+
+      assert.verifySteps(['first render', 'second render', 'third render']);
     });
   });
 });

--- a/tests/integration/modifiers/functional-modifier-test.ts
+++ b/tests/integration/modifiers/functional-modifier-test.ts
@@ -50,7 +50,7 @@ module('Integration | Modifiers | functional modifier', function (hooks) {
     test('named arguments are passed', async function (this: TestContext, assert) {
       this.registerModifier(
         'songbird',
-        modifier((_, __, { a, b }) => {
+        modifier((_, __, { a, b }: Record<string, string>) => {
           assert.equal(a, '1');
           assert.equal(b, '2');
         })

--- a/type-tests/modifier-test.ts
+++ b/type-tests/modifier-test.ts
@@ -58,15 +58,64 @@ expectTypeOf(narrowerFn).toEqualTypeOf<
   }>
 >();
 
+const narrowerFnWithEagerFalse = modifier(
+  (div: HTMLIFrameElement, pos: [string], named: Record<Foo, number>) => {
+    function handler(event: MouseEvent): void {
+      console.log(event.clientX, event.clientY, pos[0], named[Foo.Bar]);
+    }
+    div.addEventListener('mouseenter', handler);
+
+    return () => div.removeEventListener('mouseenter', handler);
+  },
+  { eager: false }
+);
+
+// Additionally, the type of the resulting modifier should be as we expect.
+expectTypeOf(narrowerFnWithEagerFalse).toEqualTypeOf<
+  FunctionBasedModifier<{
+    Args: {
+      Named: Record<Foo, number>;
+      Positional: [string];
+    };
+    Element: HTMLIFrameElement;
+  }>
+>();
+
+const narrowerFnWithEagerTrue = modifier(
+  (div: HTMLIFrameElement, pos: [string], named: Record<Foo, number>) => {
+    function handler(event: MouseEvent): void {
+      console.log(event.clientX, event.clientY, pos[0], named[Foo.Bar]);
+    }
+    div.addEventListener('mouseenter', handler);
+
+    return () => div.removeEventListener('mouseenter', handler);
+  },
+  { eager: true }
+);
+
+// Additionally, the type of the resulting modifier should be as we expect.
+expectTypeOf(narrowerFnWithEagerTrue).toEqualTypeOf<
+  FunctionBasedModifier<{
+    Args: {
+      Named: Record<Foo, number>;
+      Positional: [string];
+    };
+    Element: HTMLIFrameElement;
+  }>
+>();
+
 interface TestElementOnly {
   Element: HTMLCanvasElement;
 }
 
-const elementOnly = modifier<TestElementOnly>((el, pos, named) => {
-  expectTypeOf(el).toEqualTypeOf<HTMLCanvasElement>();
-  expectTypeOf(pos).toEqualTypeOf<unknown[]>();
-  expectTypeOf(named).toEqualTypeOf<Record<string, unknown>>();
-});
+const elementOnly = modifier<TestElementOnly>(
+  (el, pos, named) => {
+    expectTypeOf(el).toEqualTypeOf<HTMLCanvasElement>();
+    expectTypeOf(pos).toEqualTypeOf<unknown[]>();
+    expectTypeOf(named).toEqualTypeOf<object>();
+  },
+  { eager: false }
+);
 
 expectTypeOf(elementOnly).toEqualTypeOf<
   FunctionBasedModifier<{
@@ -83,11 +132,14 @@ interface NamedArgsOnly {
   };
 }
 
-const namedArgsOnly = modifier<NamedArgsOnly>((el, pos, named) => {
-  expectTypeOf(el).toEqualTypeOf<Element>();
-  expectTypeOf(pos).toEqualTypeOf<unknown[]>();
-  expectTypeOf(named).toEqualTypeOf<NamedArgsOnly['Args']['Named']>();
-});
+const namedArgsOnly = modifier<NamedArgsOnly>(
+  (el, pos, named) => {
+    expectTypeOf(el).toEqualTypeOf<Element>();
+    expectTypeOf(pos).toEqualTypeOf<unknown[]>();
+    expectTypeOf(named).toEqualTypeOf<NamedArgsOnly['Args']['Named']>();
+  },
+  { eager: false }
+);
 
 expectTypeOf(namedArgsOnly).toEqualTypeOf<
   FunctionBasedModifier<{
@@ -105,17 +157,20 @@ interface PositionalArgsOnly {
   };
 }
 
-const positionalArgsOnly = modifier<PositionalArgsOnly>((el, pos, named) => {
-  expectTypeOf(el).toEqualTypeOf<Element>();
-  expectTypeOf(pos).toEqualTypeOf<PositionalArgsOnly['Args']['Positional']>();
-  expectTypeOf(named).toEqualTypeOf<Record<string, unknown>>();
-});
+const positionalArgsOnly = modifier<PositionalArgsOnly>(
+  (el, pos, named) => {
+    expectTypeOf(el).toEqualTypeOf<Element>();
+    expectTypeOf(pos).toEqualTypeOf<PositionalArgsOnly['Args']['Positional']>();
+    expectTypeOf(named).toEqualTypeOf<object>();
+  },
+  { eager: false }
+);
 
 expectTypeOf(positionalArgsOnly).toEqualTypeOf<
   FunctionBasedModifier<{
     Element: Element;
     Args: {
-      Named: Record<string, unknown>;
+      Named: object;
       Positional: PositionalArgsOnly['Args']['Positional'];
     };
   }>
@@ -130,11 +185,14 @@ interface ArgsOnly {
   };
 }
 
-const argsOnly = modifier<ArgsOnly>((el, pos, named) => {
-  expectTypeOf(el).toEqualTypeOf<Element>();
-  expectTypeOf(pos).toEqualTypeOf<ArgsOnly['Args']['Positional']>();
-  expectTypeOf(named).toEqualTypeOf<ArgsOnly['Args']['Named']>();
-});
+const argsOnly = modifier<ArgsOnly>(
+  (el, pos, named) => {
+    expectTypeOf(el).toEqualTypeOf<Element>();
+    expectTypeOf(pos).toEqualTypeOf<ArgsOnly['Args']['Positional']>();
+    expectTypeOf(named).toEqualTypeOf<ArgsOnly['Args']['Named']>();
+  },
+  { eager: false }
+);
 
 expectTypeOf(argsOnly).toEqualTypeOf<
   FunctionBasedModifier<{
@@ -154,11 +212,14 @@ interface Full {
   };
 }
 
-const full = modifier<Full>((el, pos, named) => {
-  expectTypeOf(el).toEqualTypeOf<Full['Element']>();
-  expectTypeOf(pos).toEqualTypeOf<Full['Args']['Positional']>();
-  expectTypeOf(named).toEqualTypeOf<Full['Args']['Named']>();
-});
+const full = modifier<Full>(
+  (el, pos, named) => {
+    expectTypeOf(el).toEqualTypeOf<Full['Element']>();
+    expectTypeOf(pos).toEqualTypeOf<Full['Args']['Positional']>();
+    expectTypeOf(named).toEqualTypeOf<Full['Args']['Named']>();
+  },
+  { eager: false }
+);
 
 expectTypeOf(full).toEqualTypeOf<FunctionBasedModifier<Full>>();
 

--- a/type-tests/modifier-test.ts
+++ b/type-tests/modifier-test.ts
@@ -349,6 +349,6 @@ modifier((el) => {
 
 // --- type utilities --- //
 expectTypeOf<ModifierArgs>().toEqualTypeOf<{
-  named: Record<string, unknown>;
+  named: object;
   positional: unknown[];
 }>();


### PR DESCRIPTION
Introduce an options argument to the `modifier()` function used to create function-based modifiers, with a single initial option: `eager`. Passing `{ eager: false }` opts out of the previous default beahvior of eagerly consuming all arguments, so that function-based modifiers can have normal auto-tracking semantics -- that is, only rerunning when the tracked state they use changes. This allows users to opt into the new (`eager: false`) behavior on a per-modifier basis.

There are three changes to accompany the new options object here:

1.  Add overloads to `modifier` for the following cases:

    - the user passes no options (the default up till now)
    - the user passes `{ eager: true }` (matching the previous default)
    - the user passes `{ eager: false }` (the new target behavior)

    These overloads intentionally do *not* support invoking with a "signature" for `{ eager: false }`. If users want to introduce an explicit signature for function-based modifiers, they should first convert to the `{ eager: false }` semantics.

2.  Update the function-based modifier manager internals to support this. As a result, we now need to create a new instance each time, with the corresponding options.

3.  Update the internals of the function-based modifier manager to use a state bucket, aligning it with the internals of the class-based modifier manager and getting rid of the need for `Map`s for keeping track of modifier elements and teardowns.

---

(Docs and deprecation of the legacy behavior will follow!)