### PR TITLE
Update docs and export type utils

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -37,7 +37,7 @@ The point is to give you a path to decouple the upgrade and the migration work:
 
 ### Function-based modifiers
 
-For function-based modifiers, you simply need to pass a new options argument to the `modifier()` call.
+For function-based modifiers, the only change you need to make is to pass a new options argument to the `modifier()` call.
 
 Previously, you would write this:
 
@@ -50,17 +50,23 @@ export default modifier((el, pos, named) => {
 The exactly equivalent behavior with the new options object is:
 
 ```js
-export default modifier((el, pos, named) => {
-  // ...
-}, { eager: true });
+export default modifier(
+  (el, pos, named) => {
+    // ...
+  },
+  { eager: true }
+);
 ```
 
 To migrate to the behavior required for v4, you need to pass `{ eager: false }`:
 
 ```js
-export default modifier((el, pos, named) => {
-  // ...
-}, { eager: false });
+export default modifier(
+  (el, pos, named) => {
+    // ...
+  },
+  { eager: false }
+);
 ```
 
 
@@ -71,7 +77,7 @@ Previously, any time any argument passed to a modifier changed, Ember would re-r
 
 ### Class-based modifiers
 
-For class-based modifiers,  you need to migrate to the new `modify()` API. *All* of the old lifecycle hooks are deprecated, as are the `element`, `args`, and `isDestroying` and `isDestroyed` fields. Additionally, the  new `modify()` hook which replaces the previous lifecycle hooks is *lazy*, like auto-tracking in general. After installation, it will only be re-executed when some tracked state it uses actually changes, where previously it.
+For class-based modifiers,  you need to migrate to the new `modify()` API. *All* of the old lifecycle hooks are deprecated, as are the `element`, `args`, and `isDestroying` and `isDestroyed` fields. Additionally, the  new `modify()` hook which replaces the previous lifecycle hooks is *lazy*, like auto-tracking in general. After installation, it will only be re-executed when some tracked state it uses actually changes, where previously both `didReceiveArguments()` and `didUpdateArguments()` would be re-executed whenever any arguments to it changed, whether they used them or not.
 
 
 #### Lifecycle hooks

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -1,0 +1,356 @@
+# Migrations
+
+- [4.0](#40)
+  - [Function-based modifiers](#function-based-modifiers)
+    - [When is this a breaking change?](#when-is-this-a-breaking-change)
+  - [Class-based modifiers](#class-based-modifiers)
+    - [Lifecycle hooks](#lifecycle-hooks)
+      - [`didInstall()`](#didinstall)
+      - [`didReceiveArguments()`](#didreceivearguments)
+      - [`didUpdateArguments()`](#didupdatearguments)
+      - [`willDestroy()`](#willdestroy)
+    - [Fields](#fields)
+      - [`element`](#element)
+      - [`args`](#args)
+      - [`isDestroyed` and `isDestroying`](#isdestroyed-and-isdestroying)
+    - [When is this a breaking change?](#when-is-this-a-breaking-change-1)
+
+
+## 4.0
+
+Migrating to 4.0 requires making two significant changes to existing modifiers:
+
+- adopting "lazy" semantics for the arguments a modifier consumes (both function-based and class-based modifiers)
+- converting class-based modifiers to use a simplified API built around a single `modify` hook
+
+Prior to v3.2.0, there was no way to use normal autotracking semantics: modifiers *always* eagerly consumed their arguments. That meant they re-ran any time the arguments changed, whether or not the modifier used an argument along any given path (which is unlike the rest of Ember). Starting with v3.2.0, you can progressively migrate each modifier to use normal "lazy" semantics, where modifiers only re-run if the state they *actually use* changes, both for arguments and for any other tracked state, for example from services they inject.
+
+While `ember-modifier` is providing this in a backwards-compatible way so that you can migrate on a modifier-by-modifier basis, this change in semantics is *probably* a breaking change for people using your modifiers! If it is (as discussed in detail below), you should release a new major version after updating to use the new semantics. Additionally, for addon maintainers, note that if you release a version of your package after upgrading to 3.2.0, anyone using your modifiers will see deprecations, so you should plan to fix them *before* making that release.
+
+The point is to give you a path to decouple the upgrade and the migration work:
+
+- upgrade to 3.2.0
+- migrate to the new APIs
+- cut a new release (as a breaking change if necessary)
+- upgrade to 4.0.0 when it comes out (no changes required for your code or your consumers)
+
+
+### Function-based modifiers
+
+For function-based modifiers, you simply need to pass a new options argument to the `modifier()` call.
+
+Previously, you would write this:
+
+```js
+export default modifier((el, pos, named) => {
+  // ...
+});
+```
+
+The exactly equivalent behavior with the new options object is:
+
+```js
+export default modifier((el, pos, named) => {
+  // ...
+}, { eager: true });
+```
+
+To migrate to the behavior required for v4, you need to pass `{ eager: false }`:
+
+```js
+export default modifier((el, pos, named) => {
+  // ...
+}, { eager: false });
+```
+
+
+#### When is this a breaking change?
+
+Previously, any time any argument passed to a modifier changed, Ember would re-run the modifier. This was true whether or not you ever used the argument. This means that updating to use the `{ eager: false }` version is a breaking change for your consumers *unless* you unconditionally used all the named and positional arguments arguments to your modifier in previously.[^technically]
+
+
+### Class-based modifiers
+
+For class-based modifiers,  you need to migrate to the new `modify()` API. *All* of the old lifecycle hooks are deprecated, as are the `element`, `args`, and `isDestroying` and `isDestroyed` fields. Additionally, the  new `modify()` hook which replaces the previous lifecycle hooks is *lazy*, like auto-tracking in general. After installation, it will only be re-executed when some tracked state it uses actually changes, where previously it.
+
+
+#### Lifecycle hooks
+
+##### `didInstall()`
+
+For one-time setup done with the element in `didInstall()`, do the same setup in `modify()`. If it is cheap, you can just let it happen each time. If it is expensive, or if the operation is not [idempotent](https://en.wikipedia.org/wiki/Idempotence), you can set a flag to avoid doing it again:
+
+```js
+class Example extends Modifier {
+  didSetup = false;
+
+  modify(element, positional, named) {
+    if (!this.didSetup) {
+      // expensive setup
+      this.didSetup = true;
+    }
+
+    // ...
+  }
+}
+```
+
+
+##### `didReceiveArguments()`
+
+Since `didReceiveArguments()` ran on both installation and all subsequent times the modifier updated, you can switch directly to `modify()`. Remember that `modify()` does not eagerly consume its arguments, as discussed above, and that it receives the element and the named and positional arguments instead of requiring you to access class fields.
+
+Before:
+
+```js
+class OnModifier extends Modifier {
+  didReceiveArguments() {
+    this.element.addEventListener(
+      this.args.positional[0],
+      this.args.positional[1],
+      this.args.named.options,
+    );
+  }
+}
+```
+
+After:
+
+```js
+class OnModifier extends Modifier {
+  modify(element, [eventName, handler], { options }) {
+    element.addEventListener(eventName, handler, options);
+  }
+}
+```
+
+
+##### `didUpdateArguments()`
+
+In cases where you were using `didUpdateArguments()` to do something only when argument values *changed*, you can explicitly save the previous values and check them.
+
+Before:
+
+```js
+class Example extends Modifier {
+  didUpdateArguments() {
+    // ...
+  }
+}
+```
+
+After:
+
+```js
+class Example extends Modifier {
+  #handler;
+
+  modify(element, [handler], { when: shouldRun }) {
+    if (handler !== this.#handler) {
+      this.#handler = handler;
+
+      if (shouldRun) {
+        handler(element.getAttribute('align'));
+      }
+    }
+  }
+}
+```
+
+
+##### `willDestroy()`
+
+You can replace `willDestroy()` with Ember's [Destroyable API](https://api.emberjs.com/ember/4.2/modules/@ember%2Fdestroyable).
+
+Before:
+
+```js
+import Modifier from 'ember-modifier';
+
+export default class Example extends Modifier {
+  willDestroy() {
+    // some cleanup ...
+  }
+}
+```
+
+After:
+
+```js
+import Modifier from 'ember-modifier';
+import { registerDestructor } from '@ember/destroyable';
+
+export default class Example extends Modifier {
+  constructor(owner, args) {
+    super(owner, args);
+    registerDestructor(this, this.cleanup);
+  }
+
+  cleanup = () => {
+    // some cleanup ...
+  }
+}
+```
+
+While this is slightly longer, it means the base class does not need a `willDestroy()` hook, so you only pay for a destructor when you actually need one!
+
+
+#### Fields
+
+##### `element`
+
+The new `modify()` lifecycle hook always receives the element the modifier is installed on as its first argument, mirroring the API of function-based modifiers. Accordingly, anywhere you referenced `this.element`, you should simply refer to the `element` argument instead.
+
+Before:
+
+```js
+import Modifier from 'ember-modifier';
+
+export default class OnModifier extends Modifier {
+  onClick;
+
+  didReceiveArguments() {
+    if (this.onClick) {
+      this.element.removeEventListener('click', this.onClick);
+    }
+
+    const { onClick } = this.args.named;
+    this.onClick = onClick;
+    this.element.addEventListener('click', onClick);
+  }
+}
+```
+
+After:
+
+```js
+import Modifier from 'ember-modifier';
+
+export default class OnModifier extends Modifier {
+  onClick;
+
+  modify(element, _, { onClick }) {
+    element.removeEventListener('click', this.onClick);
+    this.onClick = onClick;
+    element.addEventListener('click', this.onClick);
+  }
+}
+```
+
+It may still be convenient to stash the element on the class! For example, you may want to provide a single teardown function which can work with the `element` and `registerDestructor`:
+
+```js
+import Modifier from 'ember-modifier';
+import { registerDestructor } from '@ember/modifier';
+
+function cleanup(instance) {
+  instance.element?.removeEventListener('click', instance.onClick);
+}
+
+export default class ClickModifier extends Modifier {
+  element;
+  onClick;
+
+  constructor(owner, args) {
+    super(owner, args);
+    registerDestructor(this, cleanup);
+  }
+
+  modify(element, [onClick]) {
+    // make them available for teardown
+    this.element = element;
+    this.onClick = onClick;
+
+    element.addEventListener('click', onClick);
+  }
+}
+```
+
+However, this is now at the discretion of the author of a modifier, rather than being true for every single modifier, and there is no need to think about whether the element is present on the class in different lifecycle hooks, because it is always available as an argument.
+
+
+##### `args`
+
+The new `modify()` lifecycle hook receives the positional and named arguments to the modifier as its second and third parameters. Previously, these were available as `this.args.positional` and `this.args.named` respectively, and became available to use in that position after calling `super(owner, args)` in the constructor. Now, the args are always available in the `modify()` hook directly.
+
+Before:
+
+```js
+import Modifier from 'ember-modifier';
+
+export default class OnModifier extends Modifier {
+  onClick;
+
+  didReceiveArguments() {
+    if (this.onClick) {
+      this.element.removeEventListener('click', this.onClick);
+    }
+
+    const { onClick } = this.args.named;
+    this.onClick = onClick;
+    this.element.addEventListener('click', onClick);
+  }
+}
+```
+
+After:
+
+```js
+import Modifier from 'ember-modifier';
+
+export default class OnModifier extends Modifier {
+  onClick;
+
+  modify(element, _, { onClick }) {
+    if (this.onClick) {
+      this.element.removeEventListener('click', this.onClick);
+    }
+
+    this.onClick = onClick;
+    this.element.addEventListener('click', onClick);
+  }
+}
+```
+
+
+##### `isDestroyed` and `isDestroying`
+
+You can replace `.isDestroyed` and `.isDestroying` checks with the corresponding functions from Ember's [Destroyable API](https://api.emberjs.com/ember/4.2/modules/@ember%2Fdestroyable).
+
+Before:
+
+```js
+import Modifier from 'ember-modifier';
+
+export default class Example extends Modifier {
+  someAction = () => {
+    if (!this.isDestroying) {
+      // ...
+    }
+  }
+}
+```
+
+After:
+
+```js
+import Modifier from 'ember-modifier';
+import { isDestroying } from '@ember/destroyable';
+
+export default class Example extends Modifier {
+  someAction = () => {
+    if (!isDestroying(this)) {
+      // ...
+    }
+  }
+}
+```
+
+
+#### When is this a breaking change?
+
+Previously, any time any argument passed to a modifier changed, Ember would re-run the modifier. This was true whether or not you ever used the argument. This means that updating to use the `{ eager: false }` version is a breaking change for your consumers *unless* you unconditionally used all the named and positional arguments arguments to your modifier in `didReceiveArguments` or `didUpdateArguments`.[^technically]
+
+
+
+[^technically]: Because modifiers re-ran any time any of their arguments changed, this left the *caller* in control of when the modifier reran. They could simply pass any tracked state as an argument to a modifier, whether the modifier used it or not or even knew it existed, and trigger this behavior. In practice, this is not relevant to the question of breaking changes. Anyone who did this was effectively relying on a quirk of Ember's initial modifier implementation to hack around the actual specified public API for a modifier!

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ function-based modifiers and more complicated class-based modifiers.
   - [Managing "side effects" effectively](#managing-side-effects-effectively)
   - [Should modifiers _always_ be self-contained?](#should-modifiers-always-be-self-contained)
 - [Usage](#usage)
-  - [Functional Modifiers](#functional-modifiers)
-    - [Generating a Functional Modifier](#generating-a-functional-modifier)
+  - [Function-Based Modifiers](#function-based-modifiers)
+    - [Generating a Function-Based Modifier](#generating-a-function-based-modifier)
     - [Example without Cleanup](#example-without-cleanup)
     - [Example with Cleanup](#example-with-cleanup)
-  - [Class Modifiers](#class-modifiers)
+  - [Class-Based Modifiers](#class-based-modifiers)
     - [Generating a Class Modifier](#generating-a-class-modifier)
     - [Example without Cleanup](#example-without-cleanup-1)
     - [Example with Cleanup](#example-with-cleanup-1)
@@ -200,32 +200,18 @@ modifiers, they should be designed with this in mind. Which specific effects are
 they trying to accomplish, how to manage them effectively, and how to do it in
 a way that is _transparent_ to the user of the modifier.
 
-### Should modifiers _always_ be self-contained?
-
-Sometimes modifiers won't be completely self-contained. For instance, the
-[`@ember/render-modifiers`](https://github.com/emberjs/ember-render-modifiers)
-package provides modifiers that call component methods directly, giving the
-component the ability to manage the side effect. This is ok, but it limits the
-reusability of whatever the component is doing, so breaking those effects out
-into individual modifiers is generally preferable.
-
-
 Usage
 ------------------------------------------------------------------------------
 
-This addon does not provide any modifiers out of the box; instead, this library
+This addon does not provide any modifiers out of the box. Instead, this library
 allows you to write your own. There are two ways to write modifiers:
 
-1. Functional modifiers
+1. Function-based modifiers
 2. Class-based modifiers
-
-```js
-import Modifier, { modifier } from 'ember-modifier';
-```
 
 These are analogous to Ember's Helper APIs, `helper` and `Helper`.
 
-### Functional Modifiers
+### Function-Based Modifiers
 
 `modifier` is an API for writing simple modifiers. For instance, you could
 implement Ember's built-in `{{on}}` modifier like so with `modifier`:
@@ -243,7 +229,7 @@ export default modifier((element, [eventName, handler]) => {
 });
 ```
 
-Functional modifiers consist of a function that receives:
+Function-based modifiers consist of a function that receives:
 
 1. The `element`
 2. An array of positional arguments
@@ -254,9 +240,9 @@ modifier((element, positional, named) => { /* */ });
 ```
 
 This function runs the first time when the element the modifier was applied to
-is inserted into the DOM, and it _autotracks_ while running. Any values that it
-accesses will be tracked, including the arguments it receives, and if any of
-them changes, the function will run again.[^changes]
+is inserted into the DOM, and it _autotracks_ while running. Any tracked values
+that it accesses will be tracked, including the arguments it receives, and if
+any of them changes, the function will run again.[^changes]
 
 The modifier can also optionally return a _destructor_. The destructor function
 will be run just before the next update, and when the element is being removed
@@ -265,7 +251,7 @@ first place.
 
 [^changes]: As with autotracking in general, “changes” here actually means that the tracked property was set—even if it was set to the same value. This is because autotracking does not cache the *values* of properties, only the last time they changed. See [this blog post](https://v5.chriskrycho.com/journal/autotracking-elegant-dx-via-cutting-edge-cs/) for a deep dive on how it works!
 
-#### Generating a Functional Modifier
+#### Generating a Function-Based Modifier
 
 To create a modifier (and a corresponding integration test), run:
 
@@ -276,8 +262,9 @@ ember g modifier scroll-top
 #### Example without Cleanup
 
 For example, if you wanted to implement your own `scrollTop` modifier (similar
-to [this](https://github.com/emberjs/ember-render-modifiers#example-scrolling-an-element-to-a-position)),
-you may do something like this:
+to [this][scroll-example]), you may do something like this:
+
+[scroll-example]: https://github.com/emberjs/ember-render-modifiers#example-scrolling-an-element-to-a-position
 
 ```js
 // app/modifiers/scroll-top.js
@@ -325,10 +312,10 @@ export default modifier(element => {
 </button>
 ```
 
-### Class Modifiers
+### Class-Based Modifiers
 
 Sometimes you may need to do something more complicated than what can be handled
-by functional modifiers. For instance:
+by function-based modifiers. For instance:
 
 1. You may need to inject services and access them
 2. You may need fine-grained control of updates, either for performance or
@@ -336,54 +323,52 @@ by functional modifiers. For instance:
    every time only to set it up again.
 3. You may need to store some local state within your modifier.
 
-In these cases, you can use a _class modifier_ instead. Here's how you would
-implement the `{{on}}` modifier with a class:
+In these cases, you can use a _class-based modifier_ instead. Here's how you
+would implement the `{{on}}` modifier with a class:
 
 ```js
 import Modifier from 'ember-modifier';
+import { registerDestructor } from '@ember/destroyable';
+
+function cleanup(instance: OnModifier) {
+  let { element, event, handler } = instance;
+
+  if (element && event && handler) {
+    element.removeEventListener(event, handler);
+
+    instance.element = null;
+    instance.event = null;
+    instance.handler = null;
+  }
+}
 
 export default class OnModifier extends Modifier {
+  element = null;
   event = null;
   handler = null;
 
-  // methods for reuse
-  addEventListener() {
-    let [event, handler] = this.args.positional;
+  modify(element, [event, handler]) {
+    this.addEventListener(element, event, handler);
+    registerDestructor(this, this.removeEventListener)
+  }
 
-    // Store the current event and handler for when we need to remove them
+  // methods for reuse
+  addEventListener = (element, event, handler) => {
+    // Store the current element, event, and handler for when we need to remove
+    // them during cleanup.
+    this.element = element;
     this.event = event;
     this.handler = handler;
 
-    this.element.addEventListener(event, handler);
-  }
-
-  removeEventListener() {
-    let { event, handler } = this;
-
-    if (event && handler) {
-      this.element.removeEventListener(event, handler);
-
-      this.event = null;
-      this.handler = null;
-    }
-  }
-
-  // lifecycle hooks
-  didReceiveArguments() {
-    this.removeEventListener();
-    this.addEventListener();
-  }
-
-  willDestroy() {
-    this.removeEventListener();
-  }
+    element.addEventListener(event, handler);
+  };
 }
 ```
 
-This may seem more complicated than the functional version, but that complexity
-comes along with much more _control_.
+While this is slightly more complicated than the function-based version, but
+that complexity comes along with much more _control_.
 
-As with functional modifiers, the lifecycle hooks of class modifiers are
+As with function-based modifiers, the lifecycle hooks of class modifiers are
 _tracked_. When they run, then any values they access will be added to the
 modifier, and the modifier will update if any of those values change.
 
@@ -404,35 +389,19 @@ This modifier can be attached to any element and accepts a single positional
 argument. When the element is inserted, and whenever the argument is updated, it
 will set the element's `scrollTop` property to the value of its argument.
 
+(Note that this example does not require the use of a class, and could be
+implemented equally well with a function-based modifier!)
+
 ```js
 // app/modifiers/scroll-position.js
-
 import Modifier from 'ember-modifier';
 
 export default class ScrollPositionModifier extends Modifier {
-  get scrollPosition() {
-    // get the first positional argument passed to the modifier
-    //
-    // {{scoll-position @someNumber relative=@someBoolean}}
-    //                  ~~~~~~~~~~~
-    //
-    return this.args.positional[0];
-  }
-
-  get isRelative() {
-    // get the named argument "relative" passed to the modifier
-    //
-    // {{scoll-position @someNumber relative=@someBoolean}}
-    //                                       ~~~~~~~~~~~~
-    //
-    return this.args.named.relative
-  }
-
-  didReceiveArguments() {
-    if(this.isRelative) {
-      this.element.scrollTop += this.scrollPosition;
+  modify(element, [scrollPosition], { relative }) {
+    if(relative) {
+      element.scrollTop += scrollPosition;
     } else {
-      this.element.scrollTop = this.scrollPosition;
+      element.scrollTop = scrollPosition;
     }
   }
 }
@@ -481,7 +450,7 @@ export default class ScrollContainerComponent extends Component {
 #### Example with Cleanup
 
 If the functionality you add in the modifier needs to be torn down when the
-modifier is removed, you can use the `willDestroy` hook.
+modifier is removed, you can use `registerDestructor` from `@ember/destroyable`.
 
 For example, if you want to have your elements dance randomly on the page using
 `setInterval`, but you wanted to make sure that was canceled when the modifier
@@ -490,42 +459,45 @@ was removed, you could do this:
 ```js
 // app/modifiers/move-randomly.js
 
-import { action } from '@ember/object';
 import Modifier from 'ember-modifier';
+import { registerDestructor } from '@ember/destroyable'
 
 const { random, round } = Math;
 const DEFAULT_DELAY = 1000;
 
+function cleanup(instance) {
+  if (instance.setIntervalId !== null) {
+    clearInterval(instance.setIntervalId);
+    instance.setIntervalId = null;
+  }
+}
+
 export default class MoveRandomlyModifier extends Modifier {
+  element = null;
   setIntervalId = null;
 
-  get delay() {
-    // get the named argument "delay" passed to the modifier
-    //
-    // {{move-randomly delay=@someNumber}}
-    //                       ~~~~~~~~~~~
-    //
-    return this.args.named.delay || DEFAULT_DELAY;
+  constructor(owner, args) {
+    super(owner, args);
+    registerDestructor(this, cleanup);
   }
 
-  @action moveElement() {
+  modify(element, _, { delay }) {
+    // Save off the element the first time for convenience with #moveElement
+    if (!this.element) {
+      this.element = element;
+    }
+
+    // Reset from any previous state.
+    cleanup(this);
+
+    this.setIntervalId = setInterval(this.#moveElement, delay ?? DEFAULT_DELAY);
+  }
+
+  #moveElement = (element) => {
     let top = round(random() * 500);
     let left = round(random() * 500);
     this.element.style.transform = `translate(${left}px, ${top}px)`;
-  }
-
-  didReceiveArguments() {
-    if (this.setIntervalId !== null) {
-      clearInterval(this.setIntervalId);
-    }
-
-    this.setIntervalId = setInterval(this.moveElement, this.delay);
-  }
-
-  willDestroy() {
-    clearInterval(this.setIntervalId);
-    this.setIntervalId = null;
-  }
+  };
 }
 ```
 
@@ -546,42 +518,34 @@ For example, suppose you wanted to track click events with `ember-metrics`:
 ```js
 // app/modifiers/track-click.js
 
-import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Modifier from 'ember-modifier';
+import { registerDestructor } from '@ember/destroyable';
 
-export default class TrackClickModifier extends Modifier {
+function cleanup(instance) {
+  instance.element?.removeEventListener('click', instance.onClick, true);
+}
+
+export default class TrackClick extends Modifier {
   @service metrics;
 
-  get eventName() {
-    // get the first positional argument passed to the modifier
-    //
-    // {{track-click "like-button-click" page="some page" title="some title"}}
-    //               ~~~~~~~~~~~~~~~~~~~
-    //
-    return this.args.positional[0];
+  constructor(owner, args) {
+    super(owner, args);
+    registerDestructor(this, this.cleanup);
   }
 
-  get options() {
-    // get the named arguments passed to the modifier
-    //
-    // {{track-click "like-button-click" page="some page" title="some title"}}
-    //                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    //
-    return this.args.named;
+  modify(element, [eventName], options) {
+    this.element = element;
+    this.eventName = eventName;
+    this.options = options;
+
+    this.cleanup();
+    element.addEventListener('click', this.onClick, true);
   }
 
-  @action onClick() {
+  onClick = () => {
     this.metrics.trackEvent(this.eventName, this.options);
-  }
-
-  didInstall() {
-    this.element.addEventListener('click', this.onClick, true);
-  }
-
-  willDestroy() {
-    this.element.removeEventListener('click', this.onClick, true);
-  }
+  };
 }
 ```
 
@@ -596,6 +560,18 @@ Usage:
 #### API
 
 <dl>
+<dt><code>constructor(owner, args)</code>
+<dd>Constructor for the modifier. You must call <code>super(...arguments)</code> before performing other initialization.</dd>
+<dt><code>modify(element, positionalArgs, namedArgs)</code>
+<dd>The primary hook for running a modifier. It gets called when the modifier is installed on the element, and any time any tracked state it uses changes. That tracked state can be from its arguments, which are auto-tracked, or from any other kind of tracked state, including but not limited to state on injected services.</dd>
+</dl>
+
+##### Deprecated
+
+These fields and hooks exist on the class until 4.0. You should migrate away
+from them to use `modify()` and the `@ember/destroyable` API as appropriate. (See [MIGRATIONS.md](./MIGRATIONS.md)).
+
+<dl>
 <dt><code>element</code></dt>
 <dd>The DOM element the modifier is attached to.</dd>
 <dt><code>args</code>: <code>{ positional: Array, named: Object }</code></dt>
@@ -604,8 +580,6 @@ Usage:
 <dd><code>true</code> if the modifier is in the process of being destroyed, or has already been destroyed.</dd>
 <dt><code>isDestroyed</code></dt>
 <dd><code>true</code> if the modifier has already been destroyed.</dd>
-<dt><code>constructor(owner, args)</code>
-<dd>Constructor for the modifier. You must call <code>super(...arguments)</code> before performing other initialization. The <code>element</code> is not yet available at this point (i.e. its value is <code>null</code> during construction).</dd>
 <dt><code>didReceiveArguments()</code></dt>
 <dd>Called when the modifier is installed <strong>and</strong> anytime the arguments are updated.</dd>
 <dt><code>didUpdateArguments()</code></dt>
@@ -620,9 +594,18 @@ Usage:
 
 ##### Lifecycle Summary
 
+Note: this table only applies to the legacy lifecycle hooks. `modify()` is mutually exclusive with all hooks except the `constructor`, and runs on installation and update, but not remove.
+
+Key:
+
+* (#) Indicates the order of invocation for the lifecycle event.
+* ❌  Indicates that the method is not invoked for a given lifecycle / property is not available.
+* ✔️  Indicates that the property is available during the invocation of the given method.
+
 <table>
 <thead><tr>
-  <th></th>
+  <th scope='column'>hook name</th>
+  <th>Create</th>
   <th>Install</th>
   <th>Update</th>
   <th>Remove</th>
@@ -631,8 +614,9 @@ Usage:
 </tr></thead>
 <tbody>
   <tr>
-    <th><code>constructor()</code></th>
-    <td>(1)</td>
+    <th scope='row'><code>constructor()</code></th>
+    <td>✔️</td>
+    <td>❌</td>
     <td>❌</td>
     <td>❌</td>
     <td>❌</td>
@@ -640,45 +624,48 @@ Usage:
   </tr>
 
   <tr>
-    <th><code>didUpdateArguments()</code></th>
-    <td>❌</td>
-    <td>(1)</td>
-    <td>❌</td>
-    <td>✔️</td>
-    <td>✔️</td>
-  </tr>
-
-  <tr>
-    <th><code>didReceiveArguments()</code></th>
-    <td>(2)</td>
-    <td>(2)</td>
-    <td>❌</td>
-    <td>✔️</td>
-    <td>✔️</td>
-  </tr>
-
-  <tr>
-    <th><code>didInstall()</code></th>
-    <td>(3)</td>
-    <td>❌</td>
-    <td>❌</td>
-    <td>✔️</td>
-    <td>✔️</td>
-  </tr>
-
-
-
-  <tr>
-    <th><code>willRemove()</code></th>
+    <th scope='row'><code>didUpdateArguments()</code></th>
     <td>❌</td>
     <td>❌</td>
     <td>(1)</td>
+    <td>❌</td>
     <td>✔️</td>
     <td>✔️</td>
   </tr>
 
   <tr>
-    <th><code>willDestroy()</code></th>
+    <th scope='row'><code>didReceiveArguments()</code></th>
+    <td>❌</td>
+    <td>(1)</td>
+    <td>(2)</td>
+    <td>❌</td>
+    <td>✔️</td>
+    <td>✔️</td>
+  </tr>
+
+  <tr>
+    <th scope='row'><code>didInstall()</code></th>
+    <td>❌</td>
+    <td>(2)</td>
+    <td>❌</td>
+    <td>❌</td>
+    <td>✔️</td>
+    <td>✔️</td>
+  </tr>
+
+  <tr>
+    <th scope='row'><code>willRemove()</code></th>
+    <td>❌</td>
+    <td>❌</td>
+    <td>❌</td>
+    <td>(1)</td>
+    <td>✔️</td>
+    <td>✔️</td>
+  </tr>
+
+  <tr>
+    <th scope='row'><code>willDestroy()</code></th>
+    <td>❌</td>
     <td>❌</td>
     <td>❌</td>
     <td>(2)</td>
@@ -688,13 +675,9 @@ Usage:
 </tbody>
 </table>
 
-* (#) Indicates the order of invocation for the lifecycle event.
-* ❌  Indicates that the method is not invoked for a given lifecycle / property is not available.
-* ✔️  Indicates that the property is available during the invocation of the given method.
-
 ## TypeScript
 
-Both the functional and class APIs can be used with TypeScript!
+Both the function- and class-based APIs can be used with TypeScript!
 
 Before checking out the [Examples with Typescript](#examples-with-type-script) below, there is an important caveat you should understand about type safety!
 
@@ -708,7 +691,7 @@ If you have a code base which is strictly typed from end to end, including with 
 [glint]: https://github.com/typed-ember/glint
 [safe-ts-libs]: https://v5.chriskrycho.com/journal/writing-robust-typescript-libraries/s
 
-To handle runtime checking, for non-type-checked templates (including projects not yet using Glint or supporting external callers), you should *act* as though the arguments passed to your modifier can be *anything*. They’re typed as `unknown` by default, which means by default TypeScript will *require* you to work out the type passed to you at runtime. For example, with the `ScrollPositionModifier` shown above, you can combine TypeScript’s [type narrowing] with the default types for the class to provide runtime errors if the caller passes the wrong types, while providing safety throughout the rest of the body of the modifier. Here, `didReceiveArguments` would be *guaranteed* to have the correct types for `this.scrollPosition` and `this.isRelative`:
+To handle runtime checking, for non-type-checked templates (including projects not yet using Glint or supporting external callers), you should *act* as though the arguments passed to your modifier can be *anything*. They’re typed as `unknown` by default, which means by default TypeScript will *require* you to work out the type passed to you at runtime. For example, with the `ScrollPositionModifier` shown above, you can combine TypeScript’s [type narrowing] with the default types for the class to provide runtime errors if the caller passes the wrong types, while providing safety throughout the rest of the body of the modifier. Here, `modify` would be *guaranteed* to have the correct types for `scrollPosition` and `relative`:
 
 [type narrowing]: https://www.typescriptlang.org/docs/handbook/advanced-types.html#type-guards-and-differentiating-types
 
@@ -717,31 +700,21 @@ import Modifier from 'ember-modifier';
 import { assert } from '@ember/debug';
 
 export class ScrollPositionModifier extends ClassBasedModifier {
-  get scrollPosition(): number {
-    const scrollValue = this.args.positional[0];
+  modify(element, [scrollPosition], { relative }) {
     assert(,
-      `first argument to 'scroll-position' must be a number, but ${scrollValue} was ${typeof scrollValue}`,
-      typeof scrollValue === "number"
+      `first argument to 'scroll-position' must be a number, but ${scrollPosition} was ${typeof scrollPosition}`,
+      typeof scrollPosition === "number"
     );
 
-    return scrollValue;
-  }
-
-  get isRelative(): boolean {
-    const { relative } = this.args.named;
     assert(
       `'relative' argument to 'scroll-position' must be a boolean, but ${relative} was ${typeof relative}`,
       typeof relative === "boolean"
     );
 
-    return relative;
-  }
-
-  didReceiveArguments() {
-    if (this.isRelative) {
-      this.element.scrollTop += this.scrollPosition;
+    if (relative) {
+      element.scrollTop += scrollPosition;
     } else {
-      this.element.scrollTop = this.scrollPosition;
+      element.scrollTop = scrollPosition;
     }
   }
 }
@@ -760,30 +733,21 @@ interface ScrollPositionModifierSignature {
       relative: boolean;
     };
   };
-  Element: Element; // not required: it'll be set by default
 }
 
 export default class ScrollPositionModifier
     extends Modifier<ScrollPositionModifierSignature> {
-  get scrollPosition(): number {
-    return this.args.positional[0];
-  }
-
-  get isRelative(): boolean {
-    return this.args.named.relative;
-  }
-
-  didReceiveArguments() {
-    if (this.isRelative) {
-      this.element.scrollTop += this.scrollPosition;
+  modify(element, [scrollPosition], { relative }) {
+    if (relative) {
+      element.scrollTop += scrollPosition;
     } else {
-      this.element.scrollTop = this.scrollPosition;
+      element.scrollTop = scrollPosition;
     }
   }
 }
 ```
 
-Besides supporting integration with [Glint][glint], this also provides nice hooks for documentation tooling. Note, however, that it can result in *much worse* feedback in tests or at runtime if someone passes the wrong kind of arguments to your modifier and you *haven't* included the assertions: users who pass the wrong thing will just have the modifier fail. For example, if you fail to pass the positional argument, `this.scrollPosition` would simply be `undefined`, and then `this.element.scrollTop` could end up being set to `NaN`. Whoops! For that reason, if your modifier will be used by non-TypeScript consumers, you should both publish the types for it *and* add dev-time assertions:
+Besides supporting integration with [Glint][glint], this also provides nice hooks for documentation tooling. Note, however, that it can result in *much worse* feedback in tests or at runtime if someone passes the wrong kind of arguments to your modifier and you *haven't* included assertions: users who pass the wrong thing will just have the modifier fail. For example, if you fail to pass the positional argument, `scrollPosition` would simply be `undefined`, and then `element.scrollTop` could end up being set to `NaN`. Whoops! For that reason, if your modifier will be used by non-TypeScript consumers, you should both publish the types for it *and* add dev-time assertions:
 
 ```ts
 // app/modifiers/scroll-position.ts
@@ -791,7 +755,7 @@ import Modifier from 'ember-modifier';
 
 interface ScrollPositionModifierSignature {
   Args: {
-    Positional: [number];
+    Positional: [scrollPosition: number];
     Named: {
       relative: boolean;
     };
@@ -801,31 +765,21 @@ interface ScrollPositionModifierSignature {
 
 export default class ScrollPositionModifier
     extends Modifier<ScrollPositionModifierSignature> {
-  get scrollPosition(): number {
-    const scrollValue = this.args.positional[0];
+  modify(element, [scrollPosition], { relative }) {
     assert(,
-      `first argument to 'scroll-position' must be a number, but ${scrollValue} was ${typeof scrollValue}`,
-      typeof scrollValue === "number"
+      `first argument to 'scroll-position' must be a number, but ${scrollPosition} was ${typeof scrollPosition}`,
+      typeof scrollPosition === "number"
     );
 
-    return scrollValue;
-  }
-
-  get isRelative(): boolean {
-    const { relative } = this.args.named;
     assert(
       `'relative' argument to 'scroll-position' must be a boolean, but ${relative} was ${typeof relative}`,
       typeof relative === "boolean"
     );
 
-    return relative;
-  }
-
-  didReceiveArguments() {
-    if (this.isRelative) {
-      this.element.scrollTop += this.scrollPosition;
+    if (relative) {
+      element.scrollTop += scrollPosition;
     } else {
-      this.element.scrollTop = this.scrollPosition;
+      element.scrollTop = scrollPosition;
     }
   }
 }
@@ -853,15 +807,39 @@ In a function-based modifier, the callback arguments will be inferred from the s
 
 ```ts
 interface MySignature {
-  // ...
+  Element: HTMLMediaElement;
+  Args: {
+    Named: {
+      when: boolean;
+    };
+    Positional: [];
+  };
 }
 
-const myModifier = modifier<MySignature>((el, pos, named) => {
-  // ...
+const play = modifier<MySignature>((el, _, { when: shouldPlay }) => {
+  if (shouldPlay) {
+    el.play();
+  } else {
+    el.pause();
+  }
 })
 ```
 
-You never *need* to specify a signature in this way for a function-based modifier. However, it is tested to keep working, since it can be useful for documentation!
+You never *need* to specify a signature in this way for a function-based modifier: you can simply write the types inline instead:
+
+```ts
+const play = modifier(
+  (el: HTMLMediaElement, _: [], { when: shouldPlay }: { when: boolean}) => {
+    if (shouldPlay) {
+      el.play();
+    } else {
+      el.pause();
+    }
+  }
+);
+```
+
+However, the explicit `modifier<Signature>(...)` form is tested to keep working, since it can be useful for documentation!
 
 The same basic approach works with a class-based modifier:
 
@@ -891,6 +869,28 @@ export default class MyModifier extends Modifier<MySignature> {
 }
 ```
 
+`ArgsFor` isn't magic: it just takes the `Args` from the `Signature` you provide and turns it into the right shape for the constructor: the `Named` type ends up as the `named` field and the `Positional` type ends up as the type for `args.positional`, so you could write it out yourself if you preferred:
+
+```ts
+import Modifier from 'ember-modifier';
+
+interface MySignature {
+  // ...
+}
+
+export default class MyModifier extends Modifier<MySignature> {
+  constructor(
+    owner: unknown,
+    args: {
+      named: MySignature['Args']['Named'];
+      positional: MySignature['Args']['Positional'];
+    }
+  ) {
+    // ...
+  }
+}
+```
+
 ### Examples with TypeScript
 
 #### Function-based modifier
@@ -904,7 +904,9 @@ import { assert } from '@ember/debug';
 
 const { random, round } = Math;
 
-export default modifier((element: HTMLElement, _: [], named: { maxOffset: number }) => {
+export default modifier(
+  (element: HTMLElement, _: [], named: { maxOffset: number }
+) => {
   assert(
     'move-randomly can only be installed on HTML elements!',
     element instanceof HTMLElement
@@ -969,7 +971,7 @@ A few things to notice here:
 To support correctly typing `args` in the `constructor` for the case where you do runtime type checking, we supply an `ArgsFor` type utility. (This is useful because the `Signature` type, matching Glimmer Component and other "invokable" items in Ember/Glimmer, has capital letters for the names of the types, while `args.named` and `args.positional` are lower-case.) Here’s how that would look with a fully typed modifier that alerts "This is a typesafe modifier!" an amount of time after receiving arguments that depends on the length of the first argument and an *optional* multiplier (a nonsensical thing to do, but one that illustrates a fully type-safe class-based modifier):
 
 ```ts
-import Modifier, { ArgsFor } from 'ember-modifier';
+import Modifier, { ArgsFor, PositionalArgs, NamedArgs } from 'ember-modifier';
 import { assert } from '@ember/debug';
 
 interface NeatSignature {
@@ -981,44 +983,43 @@ interface NeatSignature {
   }
 }
 
+
+function cleanup(instance: Neat) => {
+  if (instance.interval) {
+    clearInterval(instance.interval);
+  }
+}
+
 export default class Neat extends Modifier<NeatSignature> {
   interval?: number;
 
   constructor(owner: unknown, args: ArgsFor<NeatSignature>) {
     super(owner, args);
-    // other setup you might do
+    registerDestructor(this, cleanup);
   }
 
-  get lengthOfInput(): number {
-  	assert(
-  	  `positional arg must be 'string' but was ${typeof this.args.positional[0]}`,
-  	  typeof this.args.positional[0] === 'string'
+  modify(
+    element: Element,
+    [lengthOfInput]: PositionalArgs<NeatSignature>,
+    { multiplier }: NamedArgs<NeatSignature>
+  ) {
+    assert(
+  	  `positional arg must be 'string' but was ${typeof lengthOfInput}`,
+  	  typeof lengthOfInput === 'string'
   	);
 
-    return this.args.positional[0].length;
-  }
-
-  get multiplier(): number {
-    if (this.args.named.multiplier === undefined) {
-      return 1000;
-    }
-
     assert(
-    	`'multiplier' arg must be a number but was ${typeof this.args.named.multiplier}`,
-    	typeof this.args.named.multiplier === "number"
+    	`'multiplier' arg must be a number but was ${typeof multiplier}`,
+    	multiplier ? typeof multiplier === "number" : true
     );
 
-    return this.args.named.multiplier;
-  }
+    multiplier = modifier ?? 1000;
 
-  didReceiveArguments() {
+    let updateTime = multiplier * lengthOfInput;
     this.interval = setInterval(() => {
-      alert("this is a typesafe modifier!");
-    }, this.multiplier * this.lengthOfInput);
-  }
-
-  willDestroy() {
-    clearInterval(this.interval);
+      element.innerText =
+        `Behold, a type safe modifier moved after ${updateTime / 1000}s`;
+    }, updateTime)
   }
 }
 ```

--- a/addon/-private/signature.ts
+++ b/addon/-private/signature.ts
@@ -19,29 +19,111 @@ export type ElementFor<S> = 'Element' extends keyof S
 
 type DefaultPositional = unknown[];
 
-type Args<S, K, Fallback> = K extends keyof S
-  ? S[K] extends Fallback
-    ? S[K]
+type GetWithFallback<T, K, Fallback> = K extends keyof T
+  ? T[K] extends Fallback
+    ? T[K]
     : Fallback
   : Fallback;
 
-/** @private */
+/**
+ * A convenience type utility, primarily for working with args in the `modify`
+ * hook on class-based modifiers. Given a signature `S` it will return the
+ * correct positional args for that signature. For example:
+ *
+ * ```ts
+ * import Modifier, { NamedArgs } from 'ember-modifier';
+ *
+ * interface OnClickOutsideSig {
+ *   Args: {
+ *     Positional: [handler: () => void];
+ *   };
+ * }
+ *
+ * export default class Example extends Modifier<OnClickOutsideSig> {
+ *   element = null;
+ *
+ *   modify(el: Element, _: [handler]: PositionalArgs<OnClickOutsideSig>) {
+ *     if (!this.element) {
+ *       this.element = el;
+ *     }
+ *
+ *     this.clearHandler();
+ *     this.handler = handler;
+ *
+ *     document.addEventListener('click', this.onClickOutside);
+ *
+ *     // Normally this would be better done in `constructor` or similar.
+ *     unregisterDestructor(this, this.clearHandler);
+ *     registerDestructor(this, this.clearHandler);
+ *   }
+ *
+ *   onClickOutside = (event: MouseEvent) => {
+ *     // SAFETY: a "standard" safe cast for event.target here
+ *     if (!this.element.contains(event.target as Node)) {
+ *       this.handler();
+ *     }
+ *   }
+ *
+ *   clearHandler = () => {
+ *     document.removeEventListener('click', this.onClickOutside);
+ *   }
+ * }
+ * ```
+ *
+ * (This example does not need to be, and should not be, class-based, but is
+ * useful to illustrate how to use the type utility.)
+ */
 export type PositionalArgs<S> = 'Args' extends keyof S
-  ? Args<S['Args'], 'Positional', DefaultPositional>
-  : Args<S, 'positional', DefaultPositional>;
+  ? GetWithFallback<S['Args'], 'Positional', DefaultPositional>
+  : GetWithFallback<S, 'positional', DefaultPositional>;
 
 type DefaultNamed = object;
 
-/** @private */
+/**
+ * A convenience type utility, primarily for working with args in the `modify`
+ * hook on class-based modifiers. Given a signature `S` it will return the
+ * correct named args for that signature:
+ *
+ * ```ts
+ * import Modifier, { NamedArgs } from 'ember-modifier';
+ *
+ * interface PlaySig {
+ *   Element: HTMLElement;
+ *   Args: {
+ *     Named: {
+ *       when: string;
+ *     };
+ *   };
+ * }
+ *
+ * export default class Example extends Modifier<Sig> {
+ *   modify(el: HTMLMediaElement, _: [], { when: shouldPlay }: NamedArgs<PlaySig>) {
+ *     if (shouldPlay) {
+ *       el.play();
+ *     } else {
+ *       el.pause();
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * (This example does not need to be, and should not be, class-based, but is
+ * useful to illustrate the point.)
+ */
 export type NamedArgs<S> = 'Args' extends keyof S
-  ? Args<S['Args'], 'Named', DefaultNamed>
-  : Args<S, 'named', DefaultNamed>;
+  ? GetWithFallback<S['Args'], 'Named', DefaultNamed>
+  : GetWithFallback<S, 'named', DefaultNamed>;
 
 /** @private */
 export interface DefaultSignature {
   Element: Element;
 }
 
+/**
+ * A convenience type utility, primarily for working with args in the `modify`
+ * hook on class-based modifiers. Given a signature `S` it will return the
+ * correct positional args for that signature, to be used with
+ */
 export interface ArgsFor<S> {
   named: NamedArgs<S>;
   positional: PositionalArgs<S>;

--- a/addon/index.ts
+++ b/addon/index.ts
@@ -3,4 +3,9 @@ export {
   default as modifier,
   FunctionBasedModifier,
 } from './-private/functional/modifier';
-export type { ModifierArgs, ArgsFor } from './-private/signature';
+export type {
+  ModifierArgs,
+  ArgsFor,
+  NamedArgs,
+  PositionalArgs,
+} from './-private/signature';


### PR DESCRIPTION
- Update all docs to cover new `modify()` API and its normal auto-tracking semantics.
- Add a migration guide for v4.
- Export a handful of type signatures that will be useful for consumers working explicitly with the new `Signature` type.