### PR TITLE
Solidify types for release

### DIFF
--- a/addon/-private/class/modifier.ts
+++ b/addon/-private/class/modifier.ts
@@ -11,6 +11,7 @@ import {
 } from '../signature';
 import { assert, deprecate } from '@ember/debug';
 import { DEBUG } from '@glimmer/env';
+import Opaque from '../opaque';
 
 // SAFETY: these sets are dev-only code to avoid showing deprecations for the
 // same class more than once.
@@ -55,6 +56,18 @@ export const Element = Symbol('Element');
 
 /** @internal */
 export const Args = Symbol('Args');
+
+// Preserve the signature on a class-based modifier so it can be plucked off
+// later (by e.g. Glint), using interface merging with an opaque item to
+// preserve it in the type system. The fact that it's an empty interface is
+// actually the point: it *only* hooks the type parameter into the opaque
+// (nominal) type. Note that this is distinct from the function-based modifier
+// type intentionally, because it is actually the static class side of a
+// class-based modifier which corresponds to the result of calling `modifier()`
+// with a callback defining a function-based modifier.
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export default interface ClassBasedModifier<S = DefaultSignature>
+  extends Opaque<S> {}
 
 /**
  * A base class for modifiers which need more capabilities than function-based

--- a/addon/-private/function-based/modifier-manager.ts
+++ b/addon/-private/function-based/modifier-manager.ts
@@ -34,7 +34,7 @@ function installElement<S>(
   return installedState;
 }
 
-export default class FunctionalModifierManager<S> {
+export default class FunctionBasedModifierManager<S> {
   capabilities = capabilities(gte('3.22.0') ? '3.22' : '3.13');
 
   options: { eager: boolean };

--- a/addon/-private/function-based/modifier.ts
+++ b/addon/-private/function-based/modifier.ts
@@ -1,35 +1,24 @@
 import { deprecate } from '@ember/debug';
 import { setModifierManager } from '@ember/modifier';
+import Opaque from '../opaque';
 import {
   DefaultSignature,
   ElementFor,
   NamedArgs,
   PositionalArgs,
 } from '../signature';
-import FunctionalModifierManager from './modifier-manager';
+import FunctionBasedModifierManager from './modifier-manager';
 
 // Provide a singleton manager for each of the options. (If we extend this to
 // many more options in the future, we can revisit, but for now this means we
 // only ever allocate two managers.)
-const EAGER_MANAGER = new FunctionalModifierManager({ eager: true });
-const LAZY_MANAGER = new FunctionalModifierManager({ eager: false });
-
-// Type-only utilities used for representing the type of a Modifier in a way
-// that (a) has no runtime overhead and (b) makes no public API commitment: by
-// extending it with an interface representing the modifier, its internals
-// become literally invisible. The private field for the "brand" is not visible
-// when interacting with an interface which extends this, but it makes the type
-// non-substitutable with an empty object. This is borrowed from, and basically
-// identical to, the same time used internally in Ember's types.
-declare const Brand: unique symbol;
-declare class Opaque<T> {
-  private readonly [Brand]: T;
-}
+const EAGER_MANAGER = new FunctionBasedModifierManager({ eager: true });
+const LAZY_MANAGER = new FunctionBasedModifierManager({ eager: false });
 
 // This provides a signature whose only purpose here is to represent the runtime
 // type of a function-based modifier: an opaque item. The fact that it's an
-// empty interface is actually the point: it makes the private `[Brand]` above
-// is not visible to end users.
+// empty interface is actually the point: it *only* hooks the type parameter
+// into the opaque (nominal) type.
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface FunctionBasedModifier<S = DefaultSignature>
   extends Opaque<S> {}

--- a/addon/-private/interfaces.ts
+++ b/addon/-private/interfaces.ts
@@ -1,0 +1,4 @@
+// This re-export is here to make sure any existing type definitions which refer
+// to this path continue to work on 3.x.
+/** @deprecated */
+export type { ModifierArgs } from './signature';

--- a/addon/-private/opaque.ts
+++ b/addon/-private/opaque.ts
@@ -1,0 +1,21 @@
+// Type-only utilities used for representing the type of a Modifier in a way
+// that (a) has no runtime overhead and (b) makes no public API commitment: by
+// extending it with an interface representing the modifier, its internals
+// become literally invisible. The private field for the "brand" is not visible
+// when interacting with an interface which extends this, but it makes the type
+// non-substitutable with an empty object. This is borrowed from, and basically
+// identical to, the same time used internally in Ember's types.
+declare const Brand: unique symbol;
+declare class _Opaque<T> {
+  private readonly [Brand]: T;
+}
+
+// This provides a signature whose only purpose here is to represent the runtime
+// type of a function-based modifier: an opaque item. The fact that it's an
+// empty interface is actually the point: it makes the private `[Brand]` above
+// is not visible to end users. By exporting only this interface, we also ensure
+// we don't *ourselves* try to treat it as a class in the rest of the package.
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface Opaque<T> extends _Opaque<T> {}
+
+export default Opaque;

--- a/addon/index.ts
+++ b/addon/index.ts
@@ -2,7 +2,7 @@ export { default } from './-private/class/modifier';
 export {
   default as modifier,
   FunctionBasedModifier,
-} from './-private/functional/modifier';
+} from './-private/function-based/modifier';
 export type {
   ModifierArgs,
   ArgsFor,

--- a/type-tests/modifier-test.ts
+++ b/type-tests/modifier-test.ts
@@ -1,7 +1,7 @@
 import { expectTypeOf } from 'expect-type';
 
 import Modifier, { modifier, ModifierArgs } from 'ember-modifier';
-import { FunctionBasedModifier } from 'ember-modifier/-private/functional/modifier';
+import { FunctionBasedModifier } from 'ember-modifier/-private/function-based/modifier';
 
 // --- function modifier --- //
 expectTypeOf(modifier).toMatchTypeOf<


### PR DESCRIPTION
This includes three mostly-internal changes, but with public-facing benefits:

-   Preserve signature on class-based modifiers

    Previously, the class-based modifier was not directly using the full signature parameter, and so it could be lost in a way which made it impossible to recover from the *class*, requiring the signature itself to be visible. Attaching it via interface merging resolves that issue.

-   Re-export `ModifierArgs` from its original location

    This will make sure that any existing `.d.ts` files generated by authors of addons continue to work correctly if they reference this path.

-   Rename `Functional`-things to `FunctionBased`-things

    "Functional" has a meaning in the broader software ecosystem, and it is not simply "uses a function instead of a class". Using "function-based" is clear about what this is for.