### PR TITLE
Drop support for Node 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ on:
   pull_request:
 
 env:
-  NODE_VERSION: '12.x'
+  NODE_VERSION: '14.x'
 
 jobs:
   lint:
@@ -55,7 +55,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
 
       - name: Install Dependencies
@@ -81,7 +81,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
 
       - name: Install Dependencies
@@ -110,7 +110,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
 
       - name: Install Dependencies
@@ -148,7 +148,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
 
       - name: Install Dependencies
@@ -186,7 +186,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
 
       - name: Install Dependencies

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "webpack": "^5.58.2"
   },
   "engines": {
-    "node": "12.* || >= 14"
+    "node": "14.* || >= 16"
   },
   "prettier": {
     "singleQuote": true


### PR DESCRIPTION
To be released when Node 12 goes out of LTS at the end of April.