### PR TITLE
Target both main and v3 in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: daily
+    target-branch: v3


### PR DESCRIPTION
This makes sure that we will stay up to date on the v3 branch automatically until we drop support for it after releasing v4.