### PR TITLE
Update Class-based modifier example

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ export default class OnModifier extends Modifier {
 
   modify(element, [event, handler]) {
     this.addEventListener(element, event, handler);
-    registerDestructor(this, this.removeEventListener)
+    registerDestructor(this, cleanup)
   }
 
   // methods for reuse


### PR DESCRIPTION
This example references `this.removeEventListener` which doesn't exist. I've replaced it with the `cleanup` function which exists at the top of the example. Or should the `cleanup` function be refactored to be a `removeEventListener` method on the class instead?