### PR TITLE
Invert deprecation for missing options

### DIFF
--- a/addon/-private/function-based/modifier.ts
+++ b/addon/-private/function-based/modifier.ts
@@ -203,7 +203,7 @@ export default function modifier(
     `ember-modifier (for ${fn.name ?? fn} at ${
       new Error().stack
     }): creating a function-based modifier without options is deprecated and will be removed at v4.0`,
-    options === undefined,
+    options !== undefined,
     {
       id: 'ember-modifier.function-based-options',
       for: 'ember-modifier',


### PR DESCRIPTION
Ember's `deprecate` function has the very odd API of generating the deprecations when the predicate passed as its second condition is falsey (rather than the normal when-truthy).

Fixes #249 