### PR TITLE
Check type of teardown before saving or using it

### DIFF
--- a/addon/-private/function-based/modifier-manager.ts
+++ b/addon/-private/function-based/modifier-manager.ts
@@ -69,7 +69,7 @@ export default class FunctionBasedModifierManager<S> {
 
     const { positional, named } = args;
     const teardown = createdState.instance(element, positional, named);
-    if (teardown) {
+    if (typeof teardown === 'function') {
       state.teardown = teardown;
     }
 
@@ -84,7 +84,7 @@ export default class FunctionBasedModifierManager<S> {
     }
 
     const teardown = state.instance(state.element, args.positional, args.named);
-    if (teardown) {
+    if (typeof teardown === 'function') {
       state.teardown = teardown;
     }
 
@@ -94,7 +94,7 @@ export default class FunctionBasedModifierManager<S> {
   }
 
   destroyModifier(state: InstalledState<S>): void {
-    if (state.teardown) {
+    if (typeof state.teardown === 'function') {
       state.teardown();
     }
   }


### PR DESCRIPTION
Previously, this path "trusted" callers to only return functions in function-based modifier definitions, in line with the requirement that teardown can only be a function. However, one reasonably-common pattern with modifiers is to simply write an arrow function which performs the operation, and whose expression value is therefore the return value of the modifier definition.

For example, it's possible (though very much not advisable!) to do something like this to set a reference to the element on the passed-in object:

```js
import { set } from '@ember/object';
import { modifier } from 'ember-modifier';

export default modifier((el, [obj]) => set(obj, 'element', el));
```

This will return the *element*. We could `assert` on this, but that would make an otherwise unobjectionable pattern less friendly (even if this particular example is not one we want to encourage).

Accordingly, do not save or attempt to run non-`function` types as teardowns in function-based modifiers.

Fixes #250 