### PR TITLE
Make `FunctionBasedModifier` an (abstract) constructor type

### DIFF
--- a/addon/-private/function-based/modifier.ts
+++ b/addon/-private/function-based/modifier.ts
@@ -1,13 +1,12 @@
 import { deprecate } from '@ember/debug';
 import { setModifierManager } from '@ember/modifier';
-import Opaque from '../opaque';
 import {
-  DefaultSignature,
   ElementFor,
   ModifierArgs,
   NamedArgs,
   PositionalArgs,
 } from '../signature';
+import Modifier from '../class/modifier';
 import FunctionBasedModifierManager from './modifier-manager';
 
 // Provide a singleton manager for each of the options. (If we extend this to
@@ -16,13 +15,26 @@ import FunctionBasedModifierManager from './modifier-manager';
 const EAGER_MANAGER = new FunctionBasedModifierManager({ eager: true });
 const LAZY_MANAGER = new FunctionBasedModifierManager({ eager: false });
 
-// This provides a signature whose only purpose here is to represent the runtime
-// type of a function-based modifier: an opaque item. The fact that it's an
-// empty interface is actually the point: it *only* hooks the type parameter
-// into the opaque (nominal) type.
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface FunctionBasedModifier<S = DefaultSignature>
-  extends Opaque<S> {}
+// This type exists to provide a non-user-constructible, non-subclassable
+// type representing the conceptual "instance type" of a function modifier.
+// The abstract field of type `never` prevents subclassing in userspace of
+// the value returned from `modifier()`. By extending `Modifier<S>`, any
+// augmentations of the `Modifier` type performed by tools like Glint will
+// also apply to function-based modifiers as well.
+export declare abstract class FunctionBasedModifierInstance<
+  S
+> extends Modifier<S> {
+  protected abstract __concrete__: never;
+}
+
+// This provides a type whose only purpose here is to represent the runtime
+// type of a function-based modifier: a virtually opaque item. The fact that it's
+// a bare constructor type allows `modifier()` to preserve type parameters from
+// a generic function it's passed, and by making it abstract and impossible to
+// subclass (see above) we prevent users from attempting to instantiate the return
+// value from a `modifier()` call.
+export type FunctionBasedModifier<S> =
+  abstract new () => FunctionBasedModifierInstance<S>;
 
 /**
  * The (optional) return type for a modifier which needs to perform some kind of

--- a/tests/integration/modifiers/functional-modifier-test.ts
+++ b/tests/integration/modifiers/functional-modifier-test.ts
@@ -7,10 +7,11 @@ import { FunctionBasedModifier, modifier } from 'ember-modifier';
 import { tracked } from '@glimmer/tracking';
 
 interface TestContext extends BaseContext {
-  registerModifier(
-    name: string,
-    modifier: FunctionBasedModifier<unknown>
-  ): void;
+  // We legitimately don't care what it is here; it's only used as a hook for
+  // the tests to reference it. (This also all gets ripped out for the v4
+  // branch, so it's not especially relevant long term.)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  registerModifier(name: string, modifier: FunctionBasedModifier<any>): void;
   shouldRender?: boolean;
   isRendered?: boolean;
   value?: number;

--- a/type-tests/modifier-test.ts
+++ b/type-tests/modifier-test.ts
@@ -1,7 +1,10 @@
 import { expectTypeOf } from 'expect-type';
 
 import Modifier, { modifier, ModifierArgs } from 'ember-modifier';
-import { FunctionBasedModifier } from 'ember-modifier/-private/function-based/modifier';
+import {
+  FunctionBasedModifier,
+  FunctionBasedModifierInstance,
+} from 'ember-modifier/-private/function-based/modifier';
 import { ArgsFor, EmptyObject } from 'ember-modifier/-private/signature';
 
 // --- function modifier --- //
@@ -262,6 +265,28 @@ expectTypeOf(deprecatedForm).toEqualTypeOf<
     };
   }>
 >();
+
+const genericModifier = modifier(
+  <T>(_: Element, positional: [item: T, callback: (item: T) => void]) => {
+    return () => positional[1](positional[0]);
+  }
+);
+
+expectTypeOf(genericModifier).toEqualTypeOf<
+  abstract new <T>() => FunctionBasedModifierInstance<{
+    Args: {
+      Positional: [item: T, callback: (item: T) => void];
+      Named: EmptyObject;
+    };
+    Element: Element;
+  }>
+>();
+
+// @ts-expect-error: functional modifiers are not constructible
+new genericModifier();
+
+// @ts-expect-error: it's not possible to subclass a functional modifier
+class GenericSubclass extends genericModifier<string> {} // eslint-disable-line @typescript-eslint/no-unused-vars
 
 // This is here simply to "assert" by way of type-checking that it's possible
 // for each of the (type) arguments to be narrowed.


### PR DESCRIPTION
Similar to https://github.com/DefinitelyTyped/DefinitelyTyped/pull/59714, this PR makes `FunctionBasedModifier` an abstract constructor type. This change allows `modifier()` to accept generic functions, preserving their type parameter(s) in the type of the resulting value by virtue of it being a bare constructor type.

This type is declared to produce an abstract subtype of the class-based `Modifier`, so that a single augmentation from a tool like Glint will apply to all modifiers produced from this package, whether function- or class-based.

---

(cherry picked from commit bba74dac6fba06365427ad7a090a22038eac3ff2)