### PR TITLE
Use "export type" for FunctionBasedModifier interface

### DIFF
--- a/addon/index.ts
+++ b/addon/index.ts
@@ -1,8 +1,6 @@
 export { default } from './-private/class/modifier';
-export {
-  default as modifier,
-  FunctionBasedModifier,
-} from './-private/function-based/modifier';
+export { default as modifier } from './-private/function-based/modifier';
+export type { FunctionBasedModifier } from './-private/function-based/modifier';
 export type {
   ModifierArgs,
   ArgsFor,


### PR DESCRIPTION
Without this change you get a broken reexport when built by babel, because it doesn't know to strip FunctionBasedModifier out of index.ts, but it does know to strip it out of -private/function-based/modifier.ts.

This results in a warning from webpack when using embroider. It's also technically a SyntaxError to try to reexport a thing that doesn't exist.

---

(cherry picked from commit b93cf566cd7655140b8d1a01bdc478e86065d994)