### PR TITLE
Fix deprecation notice

### DIFF
--- a/addon/-private/function-based/modifier.ts
+++ b/addon/-private/function-based/modifier.ts
@@ -231,7 +231,7 @@ export default function modifier(
     `ember-modifier (for ${fn.name ?? fn} at ${
       new Error().stack
     }): creating a function-based modifier with \`{ eager: true }\` is deprecated and will be removed at v4.0`,
-    options?.eager === true,
+    options?.eager === false,
     {
       id: 'ember-modifier.function-based-options',
       for: 'ember-modifier',


### PR DESCRIPTION
Deprecations are shown if the test is falsy. Correctly passing `{eager: false}` triggered the notice because `options?.eager === true` evaluated to false.