### PR TITLE
Update function-based modifier in blueprint

### DIFF
--- a/blueprints/modifier/files/__root__/__collection__/__name__.js
+++ b/blueprints/modifier/files/__root__/__collection__/__name__.js
@@ -2,7 +2,7 @@
 
 export default modifier(function <%= camelizedModuleName %>(element/*, positional, named*/) {
 
-});<% } else { %>import Modifier from 'ember-modifier';
+}, { eager: false });<% } else { %>import Modifier from 'ember-modifier';
 
 export default class <%= classifiedModuleName %>Modifier extends Modifier {
 


### PR DESCRIPTION
This is related to #315.

This would allow to generate new function-based modifier without deprecation in v3.
This is not needed in v4 as only `true` value supported for `eager` option.