### PR TITLE
Fix `watchDependencies` usage

### DIFF
--- a/addon/rollup.config.js
+++ b/addon/rollup.config.js
@@ -1,5 +1,4 @@
 import typescript from 'rollup-plugin-ts';
-// import babel from '@rollup/plugin-babel';
 import { Addon } from '@embroider/addon-dev/rollup';
 
 const addon = new Addon({

--- a/test-app/ember-cli-build.js
+++ b/test-app/ember-cli-build.js
@@ -1,14 +1,12 @@
 'use strict';
 
-const rebuildAddons = process.env.EMBROIDER_REBUILD_ADDONS;
-
-process.env.EMBROIDER_REBUILD_ADDONS =
-  (rebuildAddons ? rebuildAddons + ',' : '') + 'ember-modifier';
-
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function (defaults) {
   let app = new EmberApp(defaults, {
+    autoImport: {
+      watchDependencies: ['ember-modifier'],
+    },
     // Add options here
   });
 


### PR DESCRIPTION
This was incorrectly setup during convertion to v2 addon format in #296