### PR TITLE
The package must be public

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-modifier",
-  "version": "4.0.0-beta.0",
+  "version": "3.2.7",
   "description": "A library for writing Ember modifiers",
   "keywords": [
     "ember-addon"

--- a/addon/package.json
+++ b/addon/package.json
@@ -1,7 +1,6 @@
 {
   "name": "ember-modifier",
   "version": "4.0.0-beta.0",
-  "private": true,
   "description": "A library for writing Ember modifiers",
   "keywords": [
     "ember-addon"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.0.0-beta.0",
+  "version": "3.2.7",
   "private": true,
   "repository": {
     "type": "git",

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-app",
-  "version": "4.0.0-beta.0",
+  "version": "3.2.7",
   "private": true,
   "description": "A library for writing Ember modifiers",
   "keywords": [],
@@ -54,7 +54,7 @@
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.2",
-    "ember-modifier": "4.0.0-beta.0",
+    "ember-modifier": "3.2.7",
     "ember-qunit": "^5.1.5",
     "ember-resolver": "^8.0.3",
     "ember-source": "~4.3.0",


### PR DESCRIPTION
When converting to a monorepo, we accidentally made the addon package itself `"private": true` as well as the test app and the root package. This resulted in our not actually publishing it!