### PR TITLE
Include `blueprints` folder in published tarball

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -32,6 +32,7 @@
   },
   "files": [
     "addon-main.js",
+    "blueprints",
     "dist"
   ],
   "scripts": {


### PR DESCRIPTION
This was missed in #296 and `ember-modifier@4.0.0-beta.1` did miss `blueprints` folder:

```
% npm pack ember-modifier@v4.0.0-beta.1                 
npm notice 
npm notice 📦  ember-modifier@4.0.0-beta.1
npm notice === Tarball Contents === 
npm notice 99B    addon-main.js               
npm notice 6.8kB  dist/index.js               
npm notice 1B     dist/-private/signature.js  
npm notice 2.7kB  package.json                
npm notice 27.0kB CHANGELOG.md                
npm notice 1.1kB  LICENSE.md                  
npm notice 30.7kB README.md                   
npm notice 8.8kB  dist/index.d.ts             
npm notice 3.2kB  dist/-private/signature.d.ts
npm notice === Tarball Details === 
npm notice name:          ember-modifier                          
npm notice version:       4.0.0-beta.1                            
npm notice filename:      ember-modifier-4.0.0-beta.1.tgz         
npm notice package size:  19.7 kB                                 
npm notice unpacked size: 80.4 kB                                 
npm notice shasum:        12b791ab744beb6a6caab3b7730f7eeb52a48509
npm notice integrity:     sha512-Mg4NRDCbydlF9[...]wsuv3rDs9g13A==
npm notice total files:   9                                       
npm notice 
ember-modifier-4.0.0-beta.1.tgz
```