### PR TITLE
Options for modifier deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Function-based modifiers consist of a function that receives:
 3. An object of named arguments
 
 ```js
-modifier((element, positional, named) => { /* */ });
+modifier((element, positional, named) => { /* */ }, options);
 ```
 
 This function runs the first time when the element the modifier was applied to

--- a/addon/-private/function-based/modifier.ts
+++ b/addon/-private/function-based/modifier.ts
@@ -63,7 +63,7 @@ export type Teardown = () => unknown;
  * @deprecated Until 4.0. Calling `modifier()` without an options argument is
  *   deprecated. It is supported until 4.0 so that existing modifiers can be
  *   migrated individually. Please update your function-based modifiers to pass
- *   `{ eager: false }`.
+ *   `{ eager: false }` like so: `modifier(() => {}, { eager: false }).
  *
  * @param fn The function which defines the modifier.
  */


### PR DESCRIPTION
1. Add specific example to the deprecation warning.
2. Make a note in readme that modifier() has options argument so that people can refer to it.
3. Fixes #449 