### PR TITLE
Include @ember/owner in tsconfig types

### DIFF
--- a/addon/tsconfig.json
+++ b/addon/tsconfig.json
@@ -2,5 +2,8 @@
   "extends": "@tsconfig/ember/tsconfig.json",
   "include": [
     "src/**/*"
-  ]
+  ],
+  "compilerOptions": {
+    "types": ["@ember/owner"]
+  },
 }


### PR DESCRIPTION
Without this config, projects using ember-source [preview types](https://blog.emberjs.com/announcing-official-typescript-types-public-preview/) see this TS error:

```
node_modules/ember-modifier/dist/index.d.ts:1:23 - error TS2688: Cannot find type definition file for 'ember__owner'.

1 /// <reference types="ember__owner" />
                        ~~~~~~~~~~~~
```

While this project doesn't add the reference directive directly, it appears that with `types: []` ([the default for @tsconfig/ember](https://github.com/tsconfig/bases/pull/149)), the compiler will helpfully(?) add the directive for you. (See https://github.com/microsoft/TypeScript/issues/19874)

With this config, type-checking in my dogfood project appears to work both with and without preview types.