### PR TITLE
Use tilde instead of caret for rollup-plugin-ts

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -72,7 +72,7 @@
     "expect-type": "^0.15.0",
     "prettier": "^2.8.1",
     "rollup": "^3.9.0",
-    "rollup-plugin-ts": "^3.0.2",
+    "rollup-plugin-ts": "~3.0.2",
     "typescript": "^4.9.4"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10478,7 +10478,7 @@ rollup-plugin-delete@^2.0.0:
   dependencies:
     del "^5.1.0"
 
-rollup-plugin-ts@^3.0.2:
+rollup-plugin-ts@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rollup-plugin-ts/-/rollup-plugin-ts-3.0.2.tgz#ee1a3f9ffe202ceff0b4d2f725fa268fa0c921bf"
   integrity sha512-67qi2QTHewhLyKDG6fX3jpohWpmUPPIT/xJ7rsYK46X6MqmoWy64Ti0y8ygPfLv8mXDCdRZUofM3mTxDfCswRA==


### PR DESCRIPTION
newer rollup-plugin-ts pulls in a dependency that breaks on our node version support