### PR TITLE
Disable publish unstable workflow

### DIFF
--- a/.github/workflows/publish-unstable.yml
+++ b/.github/workflows/publish-unstable.yml
@@ -25,18 +25,18 @@ jobs:
           # This creates an .npmrc that reads the NODE_AUTH_TOKEN environment variable
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Install Dependencies
-        run: yarn install --frozen-lockfile
+#       - name: Install Dependencies
+#         run: yarn install --frozen-lockfile
 
-      # We need a workspace aware version of npm because our addon is in a subdir but our .npmrc is in the root
-      - name: npm8
-        run: npm install -g npm@8
+#       # We need a workspace aware version of npm because our addon is in a subdir but our .npmrc is in the root
+#       - name: npm8
+#         run: npm install -g npm@8
 
-      - name: set version
-        run: npm version --no-git-tag-version --workspaces-update=false `node -e "console.log(require('./package.json').version)"`-unstable.`git rev-parse --short HEAD`
-        working-directory: addon
+#       - name: set version
+#         run: npm version --no-git-tag-version --workspaces-update=false `node -e "console.log(require('./package.json').version)"`-unstable.`git rev-parse --short HEAD`
+#         working-directory: addon
 
-      - name: npm publish
-        run: npm publish --tag=unstable --verbose --workspace=addon
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+#       - name: npm publish
+#         run: npm publish --tag=unstable --verbose --workspace=addon
+#         env:
+#           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}


### PR DESCRIPTION
Per Discord discussion. So far, there does not seem much benefit out of it and it pollutes releases tab on npm