### PR TITLE
Add name to modifier function for Ember Inspector Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ function-based modifiers and more complicated class-based modifiers.
     - [Generating a Function-Based Modifier](#generating-a-function-based-modifier)
     - [Example without Cleanup](#example-without-cleanup)
     - [Example with Cleanup](#example-with-cleanup)
+    - [Ember Inspector Support](#ember-inspector-support)
   - [Class-Based Modifiers](#class-based-modifiers)
     - [Generating a Class Modifier](#generating-a-class-modifier)
     - [Example without Cleanup](#example-without-cleanup-1)
@@ -306,6 +307,17 @@ export default modifier(element => {
   {{yield}}
 </button>
 ```
+
+#### Ember Inspector Support
+
+Ember Inspector supports showing modifiers. For Function-Based Modifiers it shows the function name as modifier name.
+By default arrow functions or unamed functions will be shown as \<unknown\>. To have a name shown in the inspector use a named function or pass an extra option.
+```js
+export default modifier(element => {
+  ...
+}, { name: 'my-fn-modifier' });
+```
+
 
 ### Class-Based Modifiers
 

--- a/ember-modifier/src/-private/function-based/modifier-manager.ts
+++ b/ember-modifier/src/-private/function-based/modifier-manager.ts
@@ -79,9 +79,7 @@ export default class FunctionBasedModifierManager<S> {
     return state.instance.toString();
   }
 
-  getDebugInstance(
-    state: InstalledState<S>
-  ): FunctionBasedModifierDefinition<S> {
-    return state.instance;
+  getDebugInstance(state: InstalledState<S>): InstalledState<S> {
+    return state;
   }
 }

--- a/ember-modifier/src/-private/function-based/modifier-manager.ts
+++ b/ember-modifier/src/-private/function-based/modifier-manager.ts
@@ -74,4 +74,12 @@ export default class FunctionBasedModifierManager<S> {
       state.teardown();
     }
   }
+
+  getDebugName(state: InstalledState<S>) {
+    return state.instance.toString();
+  }
+
+  getDebugInstance(state: InstalledState<S>) {
+    return state.instance;
+  }
 }

--- a/ember-modifier/src/-private/function-based/modifier-manager.ts
+++ b/ember-modifier/src/-private/function-based/modifier-manager.ts
@@ -75,11 +75,11 @@ export default class FunctionBasedModifierManager<S> {
     }
   }
 
-  getDebugName(state: InstalledState<S>) {
+  getDebugName(state: InstalledState<S>): string {
     return state.instance.toString();
   }
 
-  getDebugInstance(state: InstalledState<S>) {
+  getDebugInstance(state: InstalledState<S>): FunctionBasedModifierDefinition<S> {
     return state.instance;
   }
 }

--- a/ember-modifier/src/-private/function-based/modifier-manager.ts
+++ b/ember-modifier/src/-private/function-based/modifier-manager.ts
@@ -79,7 +79,9 @@ export default class FunctionBasedModifierManager<S> {
     return state.instance.toString();
   }
 
-  getDebugInstance(state: InstalledState<S>): FunctionBasedModifierDefinition<S> {
+  getDebugInstance(
+    state: InstalledState<S>
+  ): FunctionBasedModifierDefinition<S> {
     return state.instance;
   }
 }

--- a/ember-modifier/src/-private/function-based/modifier.ts
+++ b/ember-modifier/src/-private/function-based/modifier.ts
@@ -134,7 +134,7 @@ export default function modifier(
   // type of `setModifierManager` today is `void`; we pretend it actually
   // returns an opaque `Modifier` type so that we can provide a result from this
   // type which is useful to TS-aware tooling (e.g. Glint).
-  fn.name = name;
+  fn.name = name || fn.name;
   return setModifierManager(
     () => MANAGER,
     fn

--- a/ember-modifier/src/-private/function-based/modifier.ts
+++ b/ember-modifier/src/-private/function-based/modifier.ts
@@ -123,7 +123,7 @@ export default function modifier(
     named: object
   ) => void | Teardown,
   options?: {
-    name: string
+    name: string;
   }
 ): FunctionBasedModifier<{
   Element: Element;

--- a/ember-modifier/src/-private/function-based/modifier.ts
+++ b/ember-modifier/src/-private/function-based/modifier.ts
@@ -122,7 +122,9 @@ export default function modifier(
     positional: unknown[],
     named: object
   ) => void | Teardown,
-  name?: string
+  options?: {
+    name: string
+  }
 ): FunctionBasedModifier<{
   Element: Element;
   Args: {
@@ -130,11 +132,11 @@ export default function modifier(
     Positional: unknown[];
   };
 }> {
+  fn.toString = () => options?.name || fn.name;
   // SAFETY: the cast here is a *lie*, but it is a useful one. The actual return
   // type of `setModifierManager` today is `void`; we pretend it actually
   // returns an opaque `Modifier` type so that we can provide a result from this
   // type which is useful to TS-aware tooling (e.g. Glint).
-  fn.toString = () => name || fn.name;
   return setModifierManager(
     () => MANAGER,
     fn

--- a/ember-modifier/src/-private/function-based/modifier.ts
+++ b/ember-modifier/src/-private/function-based/modifier.ts
@@ -134,7 +134,7 @@ export default function modifier(
   // type of `setModifierManager` today is `void`; we pretend it actually
   // returns an opaque `Modifier` type so that we can provide a result from this
   // type which is useful to TS-aware tooling (e.g. Glint).
-  fn.name = name || fn.name;
+  fn.toString = () => name || fn.name;
   return setModifierManager(
     () => MANAGER,
     fn

--- a/ember-modifier/src/-private/function-based/modifier.ts
+++ b/ember-modifier/src/-private/function-based/modifier.ts
@@ -121,7 +121,8 @@ export default function modifier(
     element: Element,
     positional: unknown[],
     named: object
-  ) => void | Teardown
+  ) => void | Teardown,
+  name?: string
 ): FunctionBasedModifier<{
   Element: Element;
   Args: {
@@ -133,6 +134,7 @@ export default function modifier(
   // type of `setModifierManager` today is `void`; we pretend it actually
   // returns an opaque `Modifier` type so that we can provide a result from this
   // type which is useful to TS-aware tooling (e.g. Glint).
+  fn.name = name;
   return setModifierManager(
     () => MANAGER,
     fn


### PR DESCRIPTION
modifiers are now included in the inspector. to be able to display them they need a name. otherwise `<unknown>` will be shown. Currently the source code is displayed instead because of a bug in glimmer...

See also https://github.com/glimmerjs/glimmer-vm/pull/1591