### PR TITLE
Remove dependabot from v3 branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,3 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
-  - package-ecosystem: npm
-    directory: '/'
-    schedule:
-      interval: daily
-    target-branch: v3


### PR DESCRIPTION
v4 as released in the end of 2022. we haven't updated v3 since then so it's not needed to keep dependabot trying to upgrade it