### PR TITLE
Remove unneeded peers

### DIFF
--- a/ember-modifier/package.json
+++ b/ember-modifier/package.json
@@ -87,14 +87,6 @@
     "typescript": "^5.5.4",
     "webpack": "^5.94.0"
   },
-  "peerDependencies": {
-    "ember-source": "^3.24 || >=4.0"
-  },
-  "peerDependenciesMeta": {
-    "ember-source": {
-      "optional": true
-    }
-  },
   "volta": {
     "extends": "../package.json"
   },


### PR DESCRIPTION
embroider, auto-import, and ember-cli before them handled virtual deps without a package.json entry.

package.json entries win over virtual deps, so we don't want to declare ember-source or @glimmer/tracking as peers.


Related:
- https://github.com/tracked-tools/tracked-toolbox/pull/211
- https://github.com/emberjs/ember-test-helpers/pull/1543
- https://github.com/NullVoxPopuli/ember-resources/pull/1189
- https://github.com/NullVoxPopuli/ember-modify-based-class-resource/pull/20
- https://github.com/universal-ember/kolay/pull/187
- https://github.com/universal-ember/reactiveweb/pull/139
- https://github.com/universal-ember/ember-primitives/pull/471
- https://github.com/universal-ember/docs-support/pull/77
