### PR TITLE
Update README.md: Fix "Example with Service Injection"

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,7 +537,7 @@ export default class TrackClick extends Modifier {
 
   constructor(owner, args) {
     super(owner, args);
-    registerDestructor(this, this.cleanup);
+    registerDestructor(this, cleanup);
   }
 
   modify(element, [eventName], options) {
@@ -545,7 +545,7 @@ export default class TrackClick extends Modifier {
     this.eventName = eventName;
     this.options = options;
 
-    this.cleanup();
+    cleanup();
     element.addEventListener('click', this.onClick, true);
   }
 


### PR DESCRIPTION
It appears that the example code for "Example with Service Injection" is incorrect: It makes a `this.cleanup()` call, but (unless I'm misunderstanding) there's no `cleanup` method defined on the Modifier class.